### PR TITLE
Indicate SDI, SSM, Parity channels created for Rx labels and ignored for Tx labels

### DIFF
--- a/Docs/Parameters XML File/ARINC429_Parameters_XML_Schema.xsd
+++ b/Docs/Parameters XML File/ARINC429_Parameters_XML_Schema.xsd
@@ -3,7 +3,7 @@
 		<xs:annotation>
 			<xs:documentation>Notes																					</xs:documentation>
 			<xs:documentation>hardwareChannel is 0-Based, range accepted is: 0-31 (cf. to respective supplier doc.)	</xs:documentation>
-			<xs:documentation>startBit is 0-Based, range accepted is: 8-31 (Tx), 0-31 (rx)							</xs:documentation>
+			<xs:documentation>startBit is 0-Based, range accepted is: 8-31 (Tx), 0-31 (Rx)							</xs:documentation>
 		</xs:annotation>
     <xs:complexType>
 		<xs:sequence>
@@ -50,8 +50,17 @@
 									</xs:simpleType>
 								</xs:element>
 								<xs:element type="xs:boolean" name="createSDIChannel" maxOccurs="1" minOccurs="0" default="false"/>
+									<xs:annotation>
+										<xs:documentation>Automatic creation of read-only VeriStand channel for SDI is only supported for Rx labels. This tag is ignored for Tx labels.</xs:documentation>
+									</xs:annotation>
 								<xs:element type="xs:boolean" name="createSSMChannel" maxOccurs="1" minOccurs="0" default="false"/>
+									<xs:annotation>
+										<xs:documentation>Automatic creation of read-only VeriStand channel for SSM is only supported for Rx labels. This tag is ignored for Tx labels.</xs:documentation>
+									</xs:annotation>
 								<xs:element type="xs:boolean" name="createParityChannel" maxOccurs="1" minOccurs="0" default="false"/>
+									<xs:annotation>
+										<xs:documentation>Automatic creation of read-only VeriStand channel for Parity is only supported for Rx labels. This tag is ignored for Tx labels.</xs:documentation>
+									</xs:annotation>
 								<xs:element name="parameter" maxOccurs="unbounded" minOccurs="1">
 									<xs:complexType>
 										<xs:choice maxOccurs="unbounded" minOccurs="0">


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-communications-bus-template/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Notes added for optional tags createSDIChannel, createSSMChannel, createParityChannel to indicate these read-only channels are created for Rx labels and ignored for Tx labels.

### Why should this Pull Request be merged?

Fixes #74 by providing documentation for custom device users and developers that clarifies the scope of special channels for SDI, SSM, and Parity.

### What testing has been done?

None.
