### PR TITLE
Provide documentation for Ballard errors

### DIFF
--- a/Source/Custom Device Support/Ballard ARINC 429 Support.lvproj
+++ b/Source/Custom Device Support/Ballard ARINC 429 Support.lvproj
@@ -57,6 +57,7 @@
 				<Property Name="NI.DISK" Type="Bool">true</Property>
 			</Item>
 			<Item Name="ballardARINC429-errors.txt" Type="Document" URL="../Docs/ballardARINC429-errors.txt"/>
+			<Item Name="Ballard-API-errors.txt" Type="Document" URL="../Docs/Ballard-API-errors.txt"/>
 		</Item>
 		<Item Name="Tests" Type="Folder">
 			<Item Name="System" Type="Folder">
@@ -578,7 +579,6 @@
 			</Item>
 			<Item Name="VeriStandTestCase.lvclass" Type="LVClass" URL="../../../../niveristand-custom-device-testing-tools/VeriStandTestCase/VeriStandTestCase.lvclass"/>
 			<Item Name="VeriStandTestUtilities.lvlib" Type="Library" URL="../../../../niveristand-custom-device-testing-tools/VeriStandTestUtilities/VeriStandTestUtilities.lvlib"/>
-			<Item Name="Create Listbox Symbols for Refresh.vi" Type="VI" URL="../Utility/Create Listbox Symbols for Refresh.vi"/>
 			<Item Name="SDI.ctl" Type="VI" URL="../Shared/SDI.ctl"/>
 		</Item>
 		<Item Name="Build Specifications" Type="Build">
@@ -644,7 +644,7 @@
 				<Property Name="Destination[3].path" Type="Path">../Built/Support/Windows/Glyphs</Property>
 				<Property Name="DestinationCount" Type="Int">4</Property>
 				<Property Name="PackedLib_callersAdapt" Type="Bool">true</Property>
-				<Property Name="Source[0].itemID" Type="Str">{DBABCADD-56F5-4478-A018-F970A71BB26D}</Property>
+				<Property Name="Source[0].itemID" Type="Str">{6B7AD81B-DFF1-4191-A237-60CE02A8B1C5}</Property>
 				<Property Name="Source[0].type" Type="Str">Container</Property>
 				<Property Name="Source[1].destinationIndex" Type="Int">0</Property>
 				<Property Name="Source[1].itemID" Type="Ref">/My Computer/Ballard ARINC 429 Engine.lvlib</Property>
@@ -672,7 +672,10 @@
 				<Property Name="Source[5].itemID" Type="Ref">/My Computer/Support Files/Glyphs</Property>
 				<Property Name="Source[5].sourceInclusion" Type="Str">Include</Property>
 				<Property Name="Source[5].type" Type="Str">Container</Property>
-				<Property Name="SourceCount" Type="Int">6</Property>
+				<Property Name="Source[6].destinationIndex" Type="Int">2</Property>
+				<Property Name="Source[6].itemID" Type="Ref">/My Computer/Support Files/Ballard-API-errors.txt</Property>
+				<Property Name="Source[6].sourceInclusion" Type="Str">Include</Property>
+				<Property Name="SourceCount" Type="Int">7</Property>
 				<Property Name="TgtF_fileDescription" Type="Str">Communication Bus Engine</Property>
 				<Property Name="TgtF_internalName" Type="Str">Communication Bus Engine</Property>
 				<Property Name="TgtF_legalCopyright" Type="Str">Copyright © 2020 </Property>
@@ -706,7 +709,7 @@
 				<Property Name="Destination[1].destName" Type="Str">Support Directory</Property>
 				<Property Name="Destination[1].path" Type="Path">../Built/Scripting/data</Property>
 				<Property Name="DestinationCount" Type="Int">2</Property>
-				<Property Name="Source[0].itemID" Type="Str">{150D783B-2A6A-4F4A-A384-EFFE24C6142B}</Property>
+				<Property Name="Source[0].itemID" Type="Str">{6B7AD81B-DFF1-4191-A237-60CE02A8B1C5}</Property>
 				<Property Name="Source[0].type" Type="Str">Container</Property>
 				<Property Name="Source[1].destinationIndex" Type="Int">0</Property>
 				<Property Name="Source[1].itemID" Type="Ref">/My Computer/Ballard ARINC 429 Scripting.lvlib</Property>
@@ -814,7 +817,6 @@
 				<Item Name="Format Message String.vi" Type="VI" URL="/&lt;vilib&gt;/Utility/error.llb/Format Message String.vi"/>
 				<Item Name="General Error Handler Core CORE.vi" Type="VI" URL="/&lt;vilib&gt;/Utility/error.llb/General Error Handler Core CORE.vi"/>
 				<Item Name="General Error Handler.vi" Type="VI" URL="/&lt;vilib&gt;/Utility/error.llb/General Error Handler.vi"/>
-				<Item Name="Get File Extension.vi" Type="VI" URL="/&lt;vilib&gt;/Utility/libraryn.llb/Get File Extension.vi"/>
 				<Item Name="Get String Text Bounds.vi" Type="VI" URL="/&lt;vilib&gt;/Utility/error.llb/Get String Text Bounds.vi"/>
 				<Item Name="Get Text Rect.vi" Type="VI" URL="/&lt;vilib&gt;/picture/picture.llb/Get Text Rect.vi"/>
 				<Item Name="GetHelpDir.vi" Type="VI" URL="/&lt;vilib&gt;/Utility/error.llb/GetHelpDir.vi"/>

--- a/Source/Custom Device Support/Docs/Ballard-API-errors.txt
+++ b/Source/Custom Device Support/Docs/Ballard-API-errors.txt
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<nidocument>
+<nicomment>
+https://github.com/ni/niveristand-ballard-arinc429-custom-device/
+</nicomment>
+<nierror code="403000">
+The card or core failed to initialize.
+</nierror>
+<nierror code="403001">
+BTI driver library error. A low-level driver API call failed. Refer to the specific error source for more information.
+</nierror>
+<nierror code="403002">
+BTI LabVIEW library error. Refer to the specific error source for the underlying LabVIEW API VI name and the internal BTI Driver error code.
+</nierror>
+<nierror code="403003">
+Error while parsing the hardware configuration file. During configuration, this error is returned if the configuration file cannot be found and parsed.
+</nierror>
+<nierror code="403004">
+The target hardware is not keyed for use with LabVIEW. Only hardware that has been keyed for LabVIEW use is supported by the BTI LabVIEW instrument driver and by the Ballard ARINC 429 custom device.
+</nierror>
+<nierror code="403005">
+When Read was called, no records were available from hardware.
+</nierror>
+</nidocument>


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-communications-bus-template/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Creates a new error text file to document Ballard API errors 403000..403005. 

### Why should this Pull Request be merged?

Providing error codes and descriptions makes it easier to debug during custom device development and use. 

### What testing has been done?

Built locally and verified that modified build spec pulls new error text file and puts it in the same destination folder as the existing error text file. 
