### PR TITLE
Disable page name editing on all but the main CD page

### DIFF
--- a/Source/Custom Device/Custom Device Ballard ARINC 429.xml
+++ b/Source/Custom Device/Custom Device Ballard ARINC 429.xml
@@ -155,6 +155,7 @@
 				<eng>Configuration Files</eng>
 				<loc>Configuration Files</loc>
 			</Name>
+			<DisallowRenaming>true</DisallowRenaming>
 			<DeleteProtection>true</DeleteProtection>
 			<GUID>5F9EF1FD-304F-4EA9-BDF8-DC215A306754</GUID>
 			<Glyph>
@@ -171,6 +172,7 @@
 				<eng>Ports</eng>
 				<loc>Ports</loc>
 			</Name>
+			<DisallowRenaming>true</DisallowRenaming>
 			<DeleteProtection>true</DeleteProtection>
 			<GUID>879B7DAF-C156-4E60-80C7-980946E79B26</GUID>
 			<Glyph>
@@ -187,6 +189,7 @@
 				<eng>CH %d</eng>
 				<loc>CH %d</loc>
 			</Name>
+			<DisallowRenaming>true</DisallowRenaming>
 			<DeleteProtection>true</DeleteProtection>
 			<Copy>Copy</Copy>
 			<GUID>4344CD5A-2266-4D64-A775-8F5615E9A1AD</GUID>
@@ -204,6 +207,7 @@
 				<eng>Database</eng>
 				<loc>Database</loc>
 			</Name>
+			<DisallowRenaming>true</DisallowRenaming>
 			<DeleteProtection>true</DeleteProtection>
 			<Copy>Copy</Copy>
 			<GUID>93911212-5CC3-4FE5-877D-B534BF9C5E40</GUID>
@@ -221,6 +225,7 @@
 				<eng>Incoming</eng>
 				<loc>Incoming</loc>
 			</Name>
+			<DisallowRenaming>true</DisallowRenaming>
 			<DeleteProtection>true</DeleteProtection>
 			<GUID>3098426F-4C09-481E-8916-57E537FEC0AE</GUID>
 			<Glyph>
@@ -237,6 +242,7 @@
 				<eng>Outgoing</eng>
 				<loc>Outgoing</loc>
 			</Name>
+			<DisallowRenaming>true</DisallowRenaming>
 			<DeleteProtection>true</DeleteProtection>
 			<GUID>7D7F8E01-8E02-4E6A-8E22-BF1B7D107645</GUID>
 			<Glyph>
@@ -253,6 +259,7 @@
 				<eng>Label</eng>
 				<loc>Label</loc>
 			</Name>
+			<DisallowRenaming>true</DisallowRenaming>
 			<DeleteProtection>true</DeleteProtection>
 			<GUID>8CE6E51F-BC83-4569-865F-9C808FB30A26</GUID>
 			<Glyph>
@@ -269,6 +276,7 @@
 				<eng>Parameter</eng>
 				<loc>Parameter</loc>
 			</Name>
+			<DisallowRenaming>true</DisallowRenaming>
 			<DeleteProtection>true</DeleteProtection>
 			<GUID>7862A4D1-00AD-42C2-8A9F-4C525861A8AC</GUID>
 			<Glyph>
@@ -285,6 +293,7 @@
 				<eng>Channel Specification</eng>
 				<loc>Channel Specification</loc>
 			</Name>
+			<DisallowRenaming>true</DisallowRenaming>
 			<DeleteProtection>true</DeleteProtection>
 			<GUID>0ceacc7e-2a0c-4161-94e4-a05224c7d47b</GUID>
 			<Glyph>
@@ -301,6 +310,7 @@
 				<eng>Status</eng>
 				<loc>Status</loc>
 			</Name>
+			<DisallowRenaming>true</DisallowRenaming>
 			<DeleteProtection>true</DeleteProtection>
 			<GUID>d3f909f4-31dd-4b46-b0c0-188c355fd2ae</GUID>
 			<Glyph>
@@ -317,6 +327,7 @@
 				<eng>Receive Time</eng>
 				<loc>Receive Time</loc>
 			</Name>
+			<DisallowRenaming>true</DisallowRenaming>
 			<DeleteProtection>true</DeleteProtection>
 			<GUID>3b6787ca-0ab3-48b7-849a-2ad8b01a43ed</GUID>
 			<Glyph>
@@ -333,6 +344,7 @@
 				<eng>Word</eng>
 				<loc>Word</loc>
 			</Name>
+			<DisallowRenaming>true</DisallowRenaming>
 			<DeleteProtection>true</DeleteProtection>
 			<GUID>f906cc29-2aac-40b2-844c-3debd55d7c10</GUID>
 			<Glyph>
@@ -349,6 +361,7 @@
 				<eng>Vendor</eng>
 				<loc>Vendor</loc>
 			</Name>
+			<DisallowRenaming>true</DisallowRenaming>
 			<DeleteProtection>true</DeleteProtection>
 			<GUID>2F6A7EFE-5C12-4510-A940-FB1E70DEF407</GUID>
 			<Glyph>
@@ -383,6 +396,7 @@
 				<eng>Protocol</eng>
 				<loc>Protocol</loc>
 			</Name>
+			<DisallowRenaming>true</DisallowRenaming>
 			<DeleteProtection>true</DeleteProtection>
 			<GUID>D8399BD9-D898-4CE7-A38F-CD0EDB89D6D6</GUID>
 			<Glyph>


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-communications-bus-template/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

This fixes #122 by adding the DisallowRenaming tag to every page except the main **Ballard ARINC 429** page, so page names can no longer be edited.

### Why should this Pull Request be merged?

This fixes a bug.

### What testing has been done?

Tested in System Explorer after building all the build specs.
