### PR TITLE
Move direction tag from parameter to channel level

### DIFF
--- a/Source/Custom Device Support/Tests/System/Import-Script-Deploy/Assets/Physical_Loopback_param.xml
+++ b/Source/Custom Device Support/Tests/System/Import-Script-Deploy/Assets/Physical_Loopback_param.xml
@@ -27,10 +27,10 @@
 	<!-- ++++++++++++++++++++++++++++ Rx Channels ++++++++++++++++++++++++++++ -->
 	<channel>
 		<hardwareChannel>0</hardwareChannel>
+		<direction>incoming</direction>
 		<label>
 			<labelDecimal>124</labelDecimal>
 			<parameter>
-				<direction>incoming</direction>
 				<encoding>BNR</encoding>
 				<signed>true</signed>
 				<startBit>18</startBit>
@@ -44,6 +44,7 @@
 	</channel>
 		<channel>
 		<hardwareChannel>2</hardwareChannel>
+		<direction>incoming</direction>
 		<label>
 			<labelDecimal>126</labelDecimal>
 			<parameter>
@@ -55,12 +56,12 @@
 				<scale>1</scale>
 				<offset>0.0</offset>
 				<unit>ft</unit>
-				<direction>Incoming</direction>
 			</parameter>
 		</label>
 	</channel>
 	<channel>
 		<hardwareChannel>4</hardwareChannel>
+		<direction>incoming</direction>
 		<label>
 			<labelDecimal>128</labelDecimal>
 			<parameter>
@@ -68,7 +69,6 @@
 				<signed>true</signed>
 				<startBit>13</startBit>
 				<numberOfBits>16</numberOfBits>
-				<direction>incoming</direction>
 				<name>Altitude_Rx</name>
 				<scale>1</scale>
 				<offset>0.0</offset>
@@ -83,7 +83,6 @@
 				<scale>1</scale>
 				<offset>0.0</offset>
 				<unit></unit>
-				<direction>INcoming</direction>
 			</parameter>
 			<parameter>
 				<encoding>Discrete</encoding>
@@ -94,17 +93,16 @@
 				<scale>1</scale>
 				<offset>0.0</offset>
 				<unit></unit>
-				<direction>INCOMING</direction>
 			</parameter>
 		</label>
 	</channel>
 <!-- +++++++++++++++++++++++++ Tx Channels +++++++++++++++++++++++++ -->
 	<channel>
 		<hardwareChannel>24</hardwareChannel>
+		<direction>outgoing</direction>
 		<label>
 			<labelDecimal>124</labelDecimal>
 			<parameter>
-				<direction>outgoing</direction>
 				<encoding>BNR</encoding>
 				<signed>true</signed>
 				<startBit>18</startBit>
@@ -119,6 +117,7 @@
 	</channel>
 	<channel>
 		<hardwareChannel>26</hardwareChannel>
+		<direction>outgoing</direction>
 		<label>
 			<labelDecimal>126</labelDecimal>
 			<parameter>
@@ -131,12 +130,12 @@
 				<offset>0.0</offset>
 				<unit>ft</unit>
 				<defaultValue>0</defaultValue>
-				<direction>outgoing</direction>
 			</parameter>
 		</label>
 	</channel>
 	<channel>
 		<hardwareChannel>28</hardwareChannel>
+		<direction>outgoing</direction>
 		<label>
 			<labelDecimal>128</labelDecimal>
 			<parameter>
@@ -149,7 +148,6 @@
 				<offset>0.0</offset>
 				<unit>m</unit>
 				<defaultValue>0</defaultValue>
-				<direction>Outgoing</direction>
 			</parameter>
 			<parameter>
 				<encoding>Discrete</encoding>
@@ -159,7 +157,6 @@
 				<name>valid_Tx</name>
 				<scale>1</scale>
 				<offset>0.0</offset>
-				<direction>OUTgoing</direction>
 				<unit></unit>
 				<defaultValue>0</defaultValue>
 			</parameter>
@@ -171,7 +168,6 @@
 				<name>current_Tx</name>
 				<scale>1</scale>
 				<offset>0.0</offset>
-				<direction>OUTGOING</direction>
 				<unit></unit>
 				<defaultValue>0</defaultValue>
 			</parameter>

--- a/Source/Custom Device Support/Tests/System/Loopback/SingleCore (P2--P3)/Assets/Parameters in Scheduled and Dynamic Labels.xml
+++ b/Source/Custom Device Support/Tests/System/Loopback/SingleCore (P2--P3)/Assets/Parameters in Scheduled and Dynamic Labels.xml
@@ -26,10 +26,10 @@
 	<!-- ++++++++++++++++++++++++++++ Rx Channels ++++++++++++++++++++++++++++ -->
 	<channel>
 		<hardwareChannel>0</hardwareChannel>
+		<direction>incoming</direction>
 		<label>
 			<labelDecimal>07</labelDecimal>
 			<parameter>
-				<direction>incoming</direction>
 				<encoding>BNR</encoding>
 				<signed>true</signed>
 				<startBit>10</startBit>
@@ -43,7 +43,6 @@
 		<label>
 			<labelDecimal>08</labelDecimal>
 			<parameter>
-				<direction>incoming</direction>
 				<encoding>BNR</encoding>
 				<signed>true</signed>
 				<startBit>10</startBit>
@@ -57,7 +56,6 @@
 		<label>
 			<labelDecimal>23</labelDecimal>
 			<parameter>
-				<direction>incoming</direction>
 				<encoding>BNR</encoding>
 				<signed>true</signed>
 				<startBit>10</startBit>
@@ -71,7 +69,6 @@
 		<label>
 			<labelDecimal>24</labelDecimal>
 			<parameter>
-				<direction>incoming</direction>
 				<encoding>BNR</encoding>
 				<signed>true</signed>
 				<startBit>10</startBit>
@@ -87,11 +84,11 @@
 	<!-- +++++++++++++++++++++++++ Tx Channels +++++++++++++++++++++++++ -->
 	<channel>
 		<hardwareChannel>24</hardwareChannel>
+		<direction>outgoing</direction>
 		<label>
 			<labelDecimal>07</labelDecimal>
 			<transferType>1</transferType>
 			<parameter>
-				<direction>outgoing</direction>
 				<encoding>BNR</encoding>
 				<signed>true</signed>
 				<startBit>10</startBit>
@@ -107,7 +104,6 @@
 			<labelDecimal>08</labelDecimal>
 			<transferType>1</transferType>
 			<parameter>
-				<direction>outgoing</direction>
 				<encoding>BNR</encoding>
 				<signed>true</signed>
 				<startBit>10</startBit>
@@ -123,7 +119,6 @@
 			<labelDecimal>23</labelDecimal>
 			<transferType>0</transferType>
 			<parameter>
-				<direction>outgoing</direction>
 				<encoding>BNR</encoding>
 				<signed>true</signed>
 				<startBit>10</startBit>
@@ -139,7 +134,6 @@
 			<labelDecimal>24</labelDecimal>
 			<transferType>0</transferType>
 			<parameter>
-				<direction>outgoing</direction>
 				<encoding>BNR</encoding>
 				<signed>true</signed>
 				<startBit>10</startBit>

--- a/Source/Custom Device Support/Tests/System/Loopback/SingleCore (P2--P3)/Assets/Parameters_DynamicLabels.xml
+++ b/Source/Custom Device Support/Tests/System/Loopback/SingleCore (P2--P3)/Assets/Parameters_DynamicLabels.xml
@@ -26,10 +26,10 @@
 	<!-- ++++++++++++++++++++++++++++ Rx Channels ++++++++++++++++++++++++++++ -->
 	<channel>
 		<hardwareChannel>0</hardwareChannel>
+		<direction>incoming</direction>
 		<label>
 			<labelDecimal>07</labelDecimal>
 			<parameter>
-				<direction>incoming</direction>
 				<encoding>BNR</encoding>
 				<signed>true</signed>
 				<startBit>10</startBit>
@@ -43,7 +43,6 @@
 		<label>
 			<labelDecimal>08</labelDecimal>
 			<parameter>
-				<direction>incoming</direction>
 				<encoding>BNR</encoding>
 				<signed>true</signed>
 				<startBit>10</startBit>
@@ -57,7 +56,6 @@
 		<label>
 			<labelDecimal>23</labelDecimal>
 			<parameter>
-				<direction>incoming</direction>
 				<encoding>BNR</encoding>
 				<signed>true</signed>
 				<startBit>10</startBit>
@@ -71,7 +69,6 @@
 		<label>
 			<labelDecimal>24</labelDecimal>
 			<parameter>
-				<direction>incoming</direction>
 				<encoding>BNR</encoding>
 				<signed>true</signed>
 				<startBit>10</startBit>
@@ -87,11 +84,11 @@
 	<!-- +++++++++++++++++++++++++ Tx Channels +++++++++++++++++++++++++ -->
 	<channel>
 		<hardwareChannel>24</hardwareChannel>
+		<direction>outgoing</direction>
 		<label>
 			<labelDecimal>07</labelDecimal>
 			<transferType>1</transferType>
 			<parameter>
-				<direction>outgoing</direction>
 				<encoding>BNR</encoding>
 				<signed>true</signed>
 				<startBit>10</startBit>
@@ -107,7 +104,6 @@
 			<labelDecimal>08</labelDecimal>
 			<transferType>1</transferType>
 			<parameter>
-				<direction>outgoing</direction>
 				<encoding>BNR</encoding>
 				<signed>true</signed>
 				<startBit>10</startBit>
@@ -123,7 +119,6 @@
 			<labelDecimal>23</labelDecimal>
 			<transferType>1</transferType>
 			<parameter>
-				<direction>outgoing</direction>
 				<encoding>BNR</encoding>
 				<signed>true</signed>
 				<startBit>10</startBit>
@@ -139,7 +134,6 @@
 			<labelDecimal>24</labelDecimal>
 			<transferType>1</transferType>
 			<parameter>
-				<direction>outgoing</direction>
 				<encoding>BNR</encoding>
 				<signed>true</signed>
 				<startBit>10</startBit>

--- a/Source/Scripting Examples/Support/Parameters in Scheduled and Dynamic Labels.xml
+++ b/Source/Scripting Examples/Support/Parameters in Scheduled and Dynamic Labels.xml
@@ -26,10 +26,10 @@
 	<!-- ++++++++++++++++++++++++++++ Rx Channels ++++++++++++++++++++++++++++ -->
 	<channel>
 		<hardwareChannel>0</hardwareChannel>
+		<direction>incoming</direction>
 		<label>
 			<labelDecimal>07</labelDecimal>
 			<parameter>
-				<direction>incoming</direction>
 				<encoding>BNR</encoding>
 				<signed>true</signed>
 				<startBit>10</startBit>
@@ -43,7 +43,6 @@
 		<label>
 			<labelDecimal>08</labelDecimal>
 			<parameter>
-				<direction>incoming</direction>
 				<encoding>BNR</encoding>
 				<signed>true</signed>
 				<startBit>10</startBit>
@@ -57,7 +56,6 @@
 		<label>
 			<labelDecimal>23</labelDecimal>
 			<parameter>
-				<direction>incoming</direction>
 				<encoding>BNR</encoding>
 				<signed>true</signed>
 				<startBit>10</startBit>
@@ -71,7 +69,6 @@
 		<label>
 			<labelDecimal>24</labelDecimal>
 			<parameter>
-				<direction>incoming</direction>
 				<encoding>BNR</encoding>
 				<signed>true</signed>
 				<startBit>10</startBit>
@@ -87,11 +84,11 @@
 	<!-- +++++++++++++++++++++++++ Tx Channels +++++++++++++++++++++++++ -->
 	<channel>
 		<hardwareChannel>24</hardwareChannel>
+		<direction>outgoing</direction>
 		<label>
 			<labelDecimal>07</labelDecimal>
 			<transferType>1</transferType>
 			<parameter>
-				<direction>outgoing</direction>
 				<encoding>BNR</encoding>
 				<signed>true</signed>
 				<startBit>10</startBit>
@@ -107,7 +104,6 @@
 			<labelDecimal>08</labelDecimal>
 			<transferType>1</transferType>
 			<parameter>
-				<direction>outgoing</direction>
 				<encoding>BNR</encoding>
 				<signed>true</signed>
 				<startBit>10</startBit>
@@ -123,7 +119,6 @@
 			<labelDecimal>23</labelDecimal>
 			<transferType>0</transferType>
 			<parameter>
-				<direction>outgoing</direction>
 				<encoding>BNR</encoding>
 				<signed>true</signed>
 				<startBit>10</startBit>
@@ -139,7 +134,6 @@
 			<labelDecimal>24</labelDecimal>
 			<transferType>0</transferType>
 			<parameter>
-				<direction>outgoing</direction>
 				<encoding>BNR</encoding>
 				<signed>true</signed>
 				<startBit>10</startBit>


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-communications-bus-template/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Moves direction tag from parameter level to channel level in example and test parameter file assets.

### Why should this Pull Request be merged?

According to the schema, direction should be a child of channel. This change makes our test and example assets compliant with schema.

### What testing has been done?

Automated unit and system tests pass. Online xml validation was attempted but failed due to lack of annotations in our test assets.