### PR TITLE
Diff VI changes before building the custom device

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,5 +4,5 @@
 
 List<String> lvVersions = ['2020']
 
-ni.vsbuild.PipelineExecutor.execute(this, 'vs_cd_build', lvVersions)
 diffPipeline(lvVersions[0])
+ni.vsbuild.PipelineExecutor.execute(this, 'vs_cd_build', lvVersions)


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-communications-bus-template/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Mirror what we did in [DSF](https://github.com/ni/niveristand-data-sharing-framework-custom-device/pull/13).
Compute VI diffs and post them to GitHub first, rather than waiting for the build to finish.

### Why should this Pull Request be merged?

No reason not to get diffs faster, especially now that we're primarily doing smaller PRs and modifying test code.

### What testing has been done?

None
