### PR TITLE
Build custom device 2021

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,10 @@
 //Leave the above line alone.  It identifies this as a groovy script.
 @Library('vs-build-tools') _
 
-List<String> lvVersions = ['2020']
+def lvVersions = [
+  32 : ['2020'],
+  64 : ['2021']
+]
 
-diffPipeline(lvVersions[0])
+diffPipeline(lvVersions)
 ni.vsbuild.PipelineExecutor.execute(this, 'vs_cd_build', lvVersions)

--- a/build.toml
+++ b/build.toml
@@ -74,7 +74,7 @@ package_output_dir = 'Source\Built'
 
 [package.payload_map]
 'Source\\Built\\Ballard' = 'documents\National Instruments\NI VeriStand {veristand_version}\Custom Devices\Ballard'
-'Source\\Built\\Errors' = 'ni-paths-NISHAREDDIR\LabVIEW Run-Time\{veristand_version}\errors\English'
+'Source\\Built\\Errors' = 'ni-paths-NISHAREDDIR{nipaths_64_bitness_suffix}\LabVIEW Run-Time\{veristand_version}\errors\English'
 
 [[package]]
 type = 'nipkg'
@@ -82,6 +82,6 @@ control_file = 'control_scripting'
 package_output_dir = 'Source\Built'
 
 [package.payload_map]
-'Source\\Built\\Scripting' = 'ni-paths-LV{veristand_version}DIR\vi.lib\addons\VeriStand Custom Device Scripting APIs\Ballard ARINC 429'
-'Source\\Built\\Scripting Examples' = 'ni-paths-LV{veristand_version}DIR\examples\NI VeriStand Custom Devices\Ballard ARINC 429'
-'Source\\Built\\Errors' = 'ni-paths-LV{veristand_version}DIR\resource\errors\English'
+'Source\\Built\\Scripting' = 'ni-paths-LV{veristand_version}DIR{nipaths_64_bitness_suffix}\vi.lib\addons\VeriStand Custom Device Scripting APIs\Ballard ARINC 429'
+'Source\\Built\\Scripting Examples' = 'ni-paths-LV{veristand_version}DIR{nipaths_64_bitness_suffix}\examples\NI VeriStand Custom Devices\Ballard ARINC 429'
+'Source\\Built\\Errors' = 'ni-paths-LV{veristand_version}DIR{nipaths_64_bitness_suffix}\resource\errors\English'

--- a/control_custom_device
+++ b/control_custom_device
@@ -12,4 +12,4 @@ XB-UserVisible: yes
 Section: Add-Ons
 XB-DisplayVersion: {display_version}
 XB-DisplayName: Ballard ARINC 429 for VeriStand {veristand_version}
-Depends: {ni-veristand-{labview_version}} (>= {labview_short_version}.0.0)
+Depends: ni-veristand-{labview_version} (>= {labview_short_version}.0.0)

--- a/control_scripting
+++ b/control_scripting
@@ -12,5 +12,5 @@ XB-UserVisible: yes
 Section: Add-Ons
 XB-DisplayVersion: {display_version}
 XB-DisplayName: Ballard ARINC 429 LabVIEW Support for VeriStand {veristand_version}
-Depends: {AUTOVERSION_ni-labview-{labview_version}-x86}, {ni-veristand-{labview_version}} (>= {labview_short_version}.0.0), ni-veristand-{veristand_version}-custom-device-labview-support-common (>= 21.0.0)
+Depends: ni-labview-{labview_version}{pkg_x86_bitness_suffix} (>= {labview_short_version}.0.0), ni-veristand-{labview_version} (>= {labview_short_version}.0.0), ni-veristand-{veristand_version}-custom-device-labview-support-common (>= 21.0.0)
 Recommends: ni-ballard-arinc-429-veristand-{veristand_version}-support (>= {display_version})


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-ballard-arinc429-custom-device/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Enables building the custom device for LabVIEW/VeriStand 2021.

### Why should this Pull Request be merged?

VeriStand 2021 needs a 64-bit build of the custom device with LabVIEW 2021 64-bit.

### What testing has been done?

Waiting on PR build.
