### PR TITLE
Fix example Parameters file Direction tag location

### DIFF
--- a/Docs/User Guide/Assets/Parameters.xml
+++ b/Docs/User Guide/Assets/Parameters.xml
@@ -4,10 +4,10 @@
 	<!-- ++++++++++++++++++++++++++++ Rx Channels ++++++++++++++++++++++++++++ -->
 	<channel>
 		<hardwareChannel>0</hardwareChannel>
+		<direction>incoming</direction>
 		<label>
 			<labelDecimal>07</labelDecimal>
 			<parameter>
-				<direction>incoming</direction>
 				<encoding>BNR</encoding>
 				<signed>true</signed>
 				<startBit>10</startBit>
@@ -21,7 +21,6 @@
 		<label>
 			<labelDecimal>23</labelDecimal>
 			<parameter>
-				<direction>incoming</direction>
 				<encoding>BNR</encoding>
 				<signed>true</signed>
 				<startBit>10</startBit>
@@ -36,11 +35,11 @@
 	<!-- +++++++++++++++++++++++++ Tx Channels +++++++++++++++++++++++++ -->
 	<channel>
 		<hardwareChannel>16</hardwareChannel>
+		<direction>outgoing</direction>
 		<label>
 			<labelDecimal>07</labelDecimal>
 			<transferType>1</transferType>
 			<parameter>
-				<direction>outgoing</direction>
 				<encoding>BNR</encoding>
 				<signed>true</signed>
 				<startBit>10</startBit>
@@ -56,7 +55,6 @@
 			<labelDecimal>23</labelDecimal>
 			<transferType>0</transferType>
 			<parameter>
-				<direction>outgoing</direction>
 				<encoding>BNR</encoding>
 				<signed>true</signed>
 				<startBit>10</startBit>


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-ballard-arinc429-custom-device/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Move Direction tag to Channel level

### Why should this Pull Request be merged?

Make the example Parameters Configuration file adhere to the schema (and match the [User Guide](https://github.com/ni/niveristand-ballard-arinc429-custom-device/blob/8ddfa7a82ce80602ed7d442e511e004c78e62860/Docs/User%20Guide/User%20Guide.md?plain=1#L33))

### What testing has been done?

Validated XML against the schema XSD
