### PR TITLE
Include label naming requirements for HW file

### DIFF
--- a/Docs/User Guide/User Guide.md
+++ b/Docs/User Guide/User Guide.md
@@ -10,6 +10,10 @@ A valid hardware configuration for the core must be provided to each instance of
 
 ![BTI XML Editor](Screenshots/BTI_XML_Configuration.PNG)
 
+Additionally, the `name` attribute for each label in the hardware configuration file should adhere to the following format in order to be recognized by the custom device: name="label #" where # is the `labelDecimal`, e.g. "label 16".  If the label uses SDI=10, the label should also include `_2` at the end of the label, e.g. "label 16_2".  The `BTI XML Editor` will generate these label names by default.
+
+Example line from hardware configuration file:  <bti:message ID="123" *name="label 16_2"* messageBufferIDRef="123123" minRate="1000" maxRate="1000" *labelDecimal="16" SDI="10"* monitor="false">
+
 A simple Hardware XML file is included for getting started with the custom device.
 
 ## Configure the Custom Device

--- a/Docs/User Guide/User Guide.md
+++ b/Docs/User Guide/User Guide.md
@@ -10,7 +10,7 @@ A valid hardware configuration for the core must be provided to each instance of
 
 ![BTI XML Editor](Screenshots/BTI_XML_Configuration.PNG)
 
-Additionally, the `name` attribute for each label in the hardware configuration file should adhere to the following format in order to be recognized by the custom device: name="label #" where # is the `labelDecimal`, e.g. "label 16".  If the label uses SDI=10, the label should also include `_2` at the end of the label, e.g. "label 16_2".  The `BTI XML Editor` will generate these label names by default.
+Additionally, the `name` attribute for each label in the hardware configuration file should adhere to the following format in order to be recognized by the custom device: name="label #" where # is the `labelDecimal`, e.g. "label 16".  If the label uses SDI, the label should also include `_N` at the end of the label, e.g. "label 16_1" for SDI=01, or "label 16_3" for SDI=11.  The `BTI XML Editor` will generate these label names by default.
 
 Example line from hardware configuration file:  <bti:message ID="123" *name="label 16_2"* messageBufferIDRef="123123" minRate="1000" maxRate="1000" *labelDecimal="16" SDI="10"* monitor="false">
 

--- a/Docs/User Guide/User Guide.md
+++ b/Docs/User Guide/User Guide.md
@@ -10,7 +10,7 @@ A valid hardware configuration for the core must be provided to each instance of
 
 ![BTI XML Editor](Screenshots/BTI_XML_Configuration.PNG)
 
-Additionally, the `name` attribute for each label in the hardware configuration file should adhere to the following format in order to be recognized by the custom device: name="label #" where # is the `labelDecimal`, e.g. "label 16".  If the label uses SDI, the label should also include `_N` at the end of the label, e.g. "label 16_1" for SDI=01, or "label 16_3" for SDI=11.  The `BTI XML Editor` will generate these label names by default.
+Additionally, the `name` attribute for each label in the hardware configuration file should adhere to the following format in order to be recognized by the custom device: name="label #" where # is the `labelDecimal`, e.g. "label 16".  If the label uses SDI, the label should also include `_N` at the end of the label, where N is the SDI in decimal form, e.g. "label 16_1" for SDI=01, or "label 16_3" for SDI=11.  The `BTI XML Editor` will *NOT* generate these label names by default, so you will need to input them in the editor or modify the hardware configuration file.
 
 Example line from hardware configuration file:  <bti:message ID="123" *name="label 16_2"* messageBufferIDRef="123123" minRate="1000" maxRate="1000" *labelDecimal="16" SDI="10"* monitor="false">
 


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-ballard-arinc429-custom-device/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Currently, the custom device requires specific naming conventions for labels in the Ballard HW file that are not required by Ballard.  In order to make this clear we need to specify in the User Guide.

### Why should this Pull Request be merged?

To avoid confusion about systems that are not deploying.

### What testing has been done?

Checked that a HW config file with names that don't match this prescription does not deploy, failing with error 430002
![image](https://user-images.githubusercontent.com/42351034/200075939-91cf232c-bfdf-45c9-bece-43f39a699058.png)
