### PR TITLE
Revert prev. proj. changes [WA]. Just disable RT Driver.vi block diag removal. Rebuild with supported LVs

### DIFF
--- a/Source/Custom Device/Ballard ARINC 429 Custom Device.lvproj
+++ b/Source/Custom Device/Ballard ARINC 429 Custom Device.lvproj
@@ -1,5 +1,5 @@
 ﻿<?xml version='1.0' encoding='UTF-8'?>
-<Project Type="Project" LVVersion="20008000">
+<Project Type="Project" LVVersion="21008000">
 	<Property Name="CCSymbols" Type="Str"></Property>
 	<Property Name="NI.LV.All.SourceOnly" Type="Bool">true</Property>
 	<Property Name="NI.Project.Description" Type="Str"></Property>
@@ -409,23 +409,25 @@
 				<Item Name="whitespace.ctl" Type="VI" URL="/&lt;vilib&gt;/Utility/error.llb/whitespace.ctl"/>
 			</Item>
 			<Item Name="ActionVIOnLoad.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 System Explorer.lvlibp/Custom Device Support/System Explorer/Implementation/System Explorer/Dynamically Called/ActionVIOnLoad.vi"/>
-			<Item Name="BTI429LV.dll" Type="Document" URL="BTI429LV.dll">
-				<Property Name="NI.PreserveRelativePath" Type="Bool">true</Property>
-			</Item>
-			<Item Name="BTICardLV.dll" Type="Document" URL="BTICardLV.dll">
-				<Property Name="NI.PreserveRelativePath" Type="Bool">true</Property>
-			</Item>
-			<Item Name="DOMUserDefRef.dll" Type="Document" URL="DOMUserDefRef.dll">
-				<Property Name="NI.PreserveRelativePath" Type="Bool">true</Property>
-			</Item>
-			<Item Name="Error Converter (ErrCode or Status).vi" Type="VI" URL="/dev/git/custom-devices/niveristand-ballard-arinc429-custom-device/Source/Custom Device Support/Hardware API/Error Converter (ErrCode or Status).vi"/>
+			<Item Name="Add Timing Channels RTM.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 System Explorer.lvlibp/System Explorer/Implementation/System Explorer/RTM/Add Timing Channels RTM.vi"/>
+			<Item Name="Asynchronous Execution Unit Compiled Information.ctl" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Engine/Custom Device/Asynchronous Execution Unit Compiled Information.ctl"/>
+			<Item Name="Block Data Reference.ctl" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/NI VeriStand/Custom Device API/Block Data Reference.ctl"/>
+			<Item Name="Can Add Timing Channels.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 System Explorer.lvlibp/System Explorer/Implementation/System Explorer/RTM/Can Add Timing Channels.vi"/>
+			<Item Name="Check if Custom Device is Enabled.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 System Explorer.lvlibp/System Explorer/Implementation/System Explorer/Check if Custom Device is Enabled.vi"/>
+			<Item Name="Compiled.Settings.ctl" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Engine/Custom Device/Compiled.Settings.ctl"/>
+			<Item Name="Custom Device Item Ref.ctl" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/NI VeriStand/Custom Device API/Custom Device Item Ref.ctl"/>
+			<Item Name="Custom Device Item Ref.ctl" Type="VI" URL="../../../Includes/Ballard ARINC 429 System Explorer.lvlibp/1abvi3w/vi.lib/NI VeriStand/Custom Device API/Custom Device Item Ref.ctl"/>
+			<Item Name="Custom Device RTM Dependency.ctl" Type="VI" URL="../../../Includes/Ballard ARINC 429 System Explorer.lvlibp/1abvi3w/vi.lib/NI VeriStand/Custom Device API/Custom Device RTM Dependency.ctl"/>
+			<Item Name="Data Reference.ctl" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/NI VeriStand/Custom Device API/Data Reference.ctl"/>
+			<Item Name="EnableDisable RTM.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 System Explorer.lvlibp/System Explorer/Implementation/System Explorer/RTM/EnableDisable RTM.vi"/>
+			<Item Name="Execution Unit Factory.lvclass" Type="LVClass" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Engine/Implementation/Execution Unit Factory/Execution Unit Factory.lvclass"/>
+			<Item Name="Execution Unit Factory.lvclass" Type="LVClass" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Engine/Interfaces/Execution Unit Factory/Execution Unit Factory.lvclass"/>
+			<Item Name="Execution Unit Information.ctl" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Engine/Interfaces/Controls/Execution Unit Information.ctl"/>
+			<Item Name="Execution Unit.lvclass" Type="LVClass" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Engine/Interfaces/Execution Unit/Execution Unit.lvclass"/>
+			<Item Name="Export Configuration RTM.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 System Explorer.lvlibp/System Explorer/Implementation/System Explorer/RTM/Export Configuration RTM.vi"/>
+			<Item Name="Import Configuration RTM.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 System Explorer.lvlibp/System Explorer/Implementation/System Explorer/RTM/Import Configuration RTM.vi"/>
 			<Item Name="Initialize.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 System Explorer.lvlibp/System Explorer/Implementation/System Explorer/Initialize.vi"/>
-			<Item Name="mscorlib" Type="VI" URL="mscorlib">
-				<Property Name="NI.PreserveRelativePath" Type="Bool">true</Property>
-			</Item>
-			<Item Name="NationalInstruments.VeriStand.Internal" Type="Document" URL="NationalInstruments.VeriStand.Internal">
-				<Property Name="NI.PreserveRelativePath" Type="Bool">true</Property>
-			</Item>
+			<Item Name="Inline Execution Unit Compiled Information.ctl" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Engine/Custom Device/Inline Execution Unit Compiled Information.ctl"/>
 			<Item Name="NationalInstruments.VeriStand.SystemDefinitionAPI" Type="Document" URL="NationalInstruments.VeriStand.SystemDefinitionAPI">
 				<Property Name="NI.PreserveRelativePath" Type="Bool">true</Property>
 			</Item>
@@ -435,11 +437,12 @@
 			<Item Name="NationalInstruments.VeriStand.XMLReader" Type="Document" URL="NationalInstruments.VeriStand.XMLReader">
 				<Property Name="NI.PreserveRelativePath" Type="Bool">true</Property>
 			</Item>
-			<Item Name="NIVeriStand_DataServices.dll" Type="Document" URL="../../../Includes/NIVeriStand_DataServices.dll"/>
+			<Item Name="RT Driver VI.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Engine/Custom Device/RT Driver VI.vi"/>
+			<Item Name="Shared Resources Factory.lvclass" Type="LVClass" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Engine/Implementation/Shared Resources Factory/Shared Resources Factory.lvclass"/>
+			<Item Name="Shared Resources Factory.lvclass" Type="LVClass" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Engine/Interfaces/Shared Resources Factory/Shared Resources Factory.lvclass"/>
 			<Item Name="Shared Resources.lvclass" Type="LVClass" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Custom Device Support/Engine/Interfaces/Shared Resources/Shared Resources.lvclass"/>
-			<Item Name="systemLogging.dll" Type="Document" URL="systemLogging.dll">
-				<Property Name="NI.PreserveRelativePath" Type="Bool">true</Property>
-			</Item>
+			<Item Name="System Explorer Dispatcher.lvclass" Type="LVClass" URL="../../../Includes/Ballard ARINC 429 System Explorer.lvlibp/System Explorer/Implementation/System Explorer Dispatcher/System Explorer Dispatcher.lvclass"/>
+			<Item Name="System Explorer Dispatcher.lvclass" Type="LVClass" URL="../../../Includes/Ballard ARINC 429 System Explorer.lvlibp/System Explorer/Interfaces/System Explorer Dispatcher/System Explorer Dispatcher.lvclass"/>
 		</Item>
 		<Item Name="Build Specifications" Type="Build">
 			<Item Name="Configuration Debug" Type="Source Distribution">
@@ -765,99 +768,10 @@
 				<Item Name="Trim Whitespace.vi" Type="VI" URL="/&lt;vilib&gt;/Utility/error.llb/Trim Whitespace.vi"/>
 				<Item Name="whitespace.ctl" Type="VI" URL="/&lt;vilib&gt;/Utility/error.llb/whitespace.ctl"/>
 			</Item>
-			<Item Name="Ballard ARINC 429 Engine.lvlibp" Type="LVLibp" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp">
-				<Item Name="ARINC 429 Scripting.lvlib" Type="Library" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Scripting/ARINC 429/ARINC 429 Scripting.lvlib"/>
-				<Item Name="Asynchronous Process Parameters.ctl" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Engine/Custom Device/Asynchronous Process Parameters.ctl"/>
-				<Item Name="Ballard ARINC 429 Hardware API.lvlib" Type="Library" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Hardware API/Ballard ARINC 429 Hardware API.lvlib"/>
-				<Item Name="Ballard ARINC 429 Scripting.lvlib" Type="Library" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Scripting/Ballard/Ballard ARINC 429 Scripting.lvlib"/>
-				<Item Name="Ballard ARINC 429 System Explorer.lvlib" Type="Library" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/System Explorer/Implementation/System Explorer/Ballard ARINC 429 System Explorer.lvlib"/>
-				<Item Name="BTI429LV.lvlib" Type="Library" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/instr.lib/BTI429Lib/BTI429LV.lvlib"/>
-				<Item Name="BTICardLV.lvlib" Type="Library" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/instr.lib/BTICardLib/BTICardLV.lvlib"/>
-				<Item Name="Build Linux Log File Path.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Shared/Build Linux Log File Path.vi"/>
-				<Item Name="BuildHelpPath.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/error.llb/BuildHelpPath.vi"/>
-				<Item Name="Check Special Tags.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/error.llb/Check Special Tags.vi"/>
-				<Item Name="Clear Errors.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/error.llb/Clear Errors.vi"/>
-				<Item Name="Convert property node font to graphics font.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/error.llb/Convert property node font to graphics font.vi"/>
-				<Item Name="Create Directory Recursive.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/libraryn.llb/Create Directory Recursive.vi"/>
-				<Item Name="Create NI GUID.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/string/Create NI GUID.vi"/>
-				<Item Name="Custom Device API.lvlib" Type="Library" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/NI VeriStand/Custom Device API/Custom Device API.lvlib"/>
-				<Item Name="Custom Device Utility Library.lvlib" Type="Library" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/NI VeriStand/Custom Device Tools/Custom Device Utility Library/Custom Device Utility Library.lvlib"/>
-				<Item Name="Custom Device.lvlib" Type="Library" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Engine/Custom Device/Custom Device.lvlib"/>
-				<Item Name="Data Access Engine.lvlib" Type="Library" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/NI/NIVS Inline Async API/_Data Access Engine/Data Access Engine.lvlib"/>
-				<Item Name="Data Word Format.ctl" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Shared/Data Word Format.ctl"/>
-				<Item Name="Details Display Dialog.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/error.llb/Details Display Dialog.vi"/>
-				<Item Name="Device Parameters.ctl" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Shared/Device Parameters.ctl"/>
-				<Item Name="DialogType.ctl" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/error.llb/DialogType.ctl"/>
-				<Item Name="DialogTypeEnum.ctl" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/error.llb/DialogTypeEnum.ctl"/>
-				<Item Name="Direction Capability.ctl" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Shared/Direction Capability.ctl"/>
-				<Item Name="Encode Parameter and Update Word (32-bit).vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Shared/Encode Parameter and Update Word (32-bit).vi"/>
-				<Item Name="Encoding and Decoding.lvlib" Type="Library" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/NI/NI VeriStand Encoding and Decoding/Encoding and Decoding.lvlib"/>
-				<Item Name="Error Cluster From Error Code.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/error.llb/Error Cluster From Error Code.vi"/>
-				<Item Name="Error Code Database.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/error.llb/Error Code Database.vi"/>
-				<Item Name="ErrWarn.ctl" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/error.llb/ErrWarn.ctl"/>
-				<Item Name="eventvkey.ctl" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/event_ctls.llb/eventvkey.ctl"/>
-				<Item Name="Find Tag.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/error.llb/Find Tag.vi"/>
-				<Item Name="Format Message String.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/error.llb/Format Message String.vi"/>
-				<Item Name="General Error Handler Core CORE.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/error.llb/General Error Handler Core CORE.vi"/>
-				<Item Name="General Error Handler.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/error.llb/General Error Handler.vi"/>
-				<Item Name="Get Label Settings for RT.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Shared/Get Label Settings for RT.vi"/>
-				<Item Name="Get Rx Hardware Channel Data.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Shared/Get Rx Hardware Channel Data.vi"/>
-				<Item Name="Get Static Channel Reference for Frame.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Shared/Get Static Channel Reference for Frame.vi"/>
-				<Item Name="Get Status Error Channel Data References.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Shared/Get Status Error Channel Data References.vi"/>
-				<Item Name="Get String Text Bounds.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/error.llb/Get String Text Bounds.vi"/>
-				<Item Name="Get Text Rect.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/picture/picture.llb/Get Text Rect.vi"/>
-				<Item Name="Get Tx Hardware Channel Data.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Shared/Get Tx Hardware Channel Data.vi"/>
-				<Item Name="GetHelpDir.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/error.llb/GetHelpDir.vi"/>
-				<Item Name="GetRTHostConnectedProp.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/error.llb/GetRTHostConnectedProp.vi"/>
-				<Item Name="Implementation.lvlib" Type="Library" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Engine/Implementation/Implementation.lvlib"/>
-				<Item Name="Initialization Method.ctl" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Shared/Initialization Method.ctl"/>
-				<Item Name="Interfaces.lvlib" Type="Library" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Engine/Interfaces/Interfaces.lvlib"/>
-				<Item Name="Label Properties.ctl" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Shared/Label Properties.ctl"/>
-				<Item Name="Label.ctl" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Shared/Label.ctl"/>
-				<Item Name="Longest Line Length in Pixels.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/error.llb/Longest Line Length in Pixels.vi"/>
-				<Item Name="LV Config Read String.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/resource/dialog/lvconfig.llb/LV Config Read String.vi"/>
-				<Item Name="LVBoundsTypeDef.ctl" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/miscctls.llb/LVBoundsTypeDef.ctl"/>
-				<Item Name="LVRectTypeDef.ctl" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/miscctls.llb/LVRectTypeDef.ctl"/>
-				<Item Name="Map of Identifiers to Indexes.ctl" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Shared/Map of Identifiers to Indexes.ctl"/>
-				<Item Name="Map of Values Indexes to Channel and Label Indexes.ctl" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Shared/Map of Values Indexes to Channel and Label Indexes.ctl"/>
-				<Item Name="Messaging.lvlib" Type="Library" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/NI/VeriStand Custom Device Messaging/Messaging.lvlib"/>
-				<Item Name="NI_SystemLogging.lvlib" Type="Library" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/SystemLogging/NI_SystemLogging.lvlib"/>
-				<Item Name="nirviCommon.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/express/rvi/timingcommon/nirviCommon.vi"/>
-				<Item Name="Not Found Dialog.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/error.llb/Not Found Dialog.vi"/>
-				<Item Name="Pack Message Identifier.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Shared/Pack Message Identifier.vi"/>
-				<Item Name="Parameter Definition.ctl" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Shared/Parameter Definition.ctl"/>
-				<Item Name="RT Hardware Channel Settings.ctl" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Shared/RT Hardware Channel Settings.ctl"/>
-				<Item Name="RT Label Settings.ctl" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Shared/RT Label Settings.ctl"/>
-				<Item Name="RT Parameters.ctl" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Shared/RT Parameters.ctl"/>
-				<Item Name="Rx Channel Data Offsets.ctl" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Shared/Rx Channel Data Offsets.ctl"/>
-				<Item Name="Search and Replace Pattern.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/error.llb/Search and Replace Pattern.vi"/>
-				<Item Name="Set Bold Text.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/error.llb/Set Bold Text.vi"/>
-				<Item Name="Set String Value.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/error.llb/Set String Value.vi"/>
-				<Item Name="Simple Error Handler.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/error.llb/Simple Error Handler.vi"/>
-				<Item Name="subTimeDelay.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/express/express execution control/TimeDelayBlock.llb/subTimeDelay.vi"/>
-				<Item Name="TagReturnType.ctl" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/error.llb/TagReturnType.ctl"/>
-				<Item Name="Three Button Dialog CORE.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/error.llb/Three Button Dialog CORE.vi"/>
-				<Item Name="Three Button Dialog.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/error.llb/Three Button Dialog.vi"/>
-				<Item Name="Transfer Type.ctl" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Shared/Transfer Type.ctl"/>
-				<Item Name="Trim Whitespace.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/error.llb/Trim Whitespace.vi"/>
-				<Item Name="Verify File Exists and Not Empty.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Shared/Verify File Exists and Not Empty.vi"/>
-				<Item Name="VS Inline Async API.lvlib" Type="Library" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/NI/NIVS Inline Async API/_VS Inline Async API/VS Inline Async API.lvlib"/>
-				<Item Name="whitespace.ctl" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/error.llb/whitespace.ctl"/>
-			</Item>
-			<Item Name="BTI429LV.dll" Type="Document" URL="BTI429LV.dll">
-				<Property Name="NI.PreserveRelativePath" Type="Bool">true</Property>
-			</Item>
-			<Item Name="BTICardLV.dll" Type="Document" URL="BTICardLV.dll">
-				<Property Name="NI.PreserveRelativePath" Type="Bool">true</Property>
-			</Item>
-			<Item Name="Error Converter (ErrCode or Status).vi" Type="VI" URL="/dev/git/custom-devices/niveristand-ballard-arinc429-custom-device/Source/Custom Device Support/Hardware API/Error Converter (ErrCode or Status).vi"/>
 			<Item Name="NationalInstruments.VeriStand.SystemStorage" Type="Document" URL="NationalInstruments.VeriStand.SystemStorage">
 				<Property Name="NI.PreserveRelativePath" Type="Bool">true</Property>
 			</Item>
-			<Item Name="NIVeriStand_DataServices.dll" Type="Document" URL="../../../Includes/NIVeriStand_DataServices.dll"/>
-			<Item Name="systemLogging.dll" Type="Document" URL="systemLogging.dll">
-				<Property Name="NI.PreserveRelativePath" Type="Bool">true</Property>
-			</Item>
+			<Item Name="RT Driver VI.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Engine/Custom Device/RT Driver VI.vi"/>
 		</Item>
 		<Item Name="Build Specifications" Type="Build">
 			<Item Name="Engine Debug" Type="Source Distribution">
@@ -896,6 +810,7 @@
 				<Property Name="Bld_localDestDirType" Type="Str">relativeToCommon</Property>
 				<Property Name="Bld_postActionVIID" Type="Ref">/My Computer/Utility/Copy .LLB to NI VeriStand dir.vi</Property>
 				<Property Name="Bld_previewCacheID" Type="Str">{E24CF77A-EDD5-435E-91DE-CAC6522BEA2A}</Property>
+				<Property Name="Bld_removeVIObj" Type="Int">1</Property>
 				<Property Name="Bld_targetDestDir" Type="Path">Linux_x64/Ballard ARINC 429 Engine Linux64.llb</Property>
 				<Property Name="Bld_version.major" Type="Int">1</Property>
 				<Property Name="Destination[0].destName" Type="Str">Destination Directory</Property>
@@ -906,33 +821,28 @@
 				<Property Name="Destination[1].path" Type="Path">/Linux_x64</Property>
 				<Property Name="Destination[1].path.type" Type="Str">&lt;none&gt;</Property>
 				<Property Name="DestinationCount" Type="Int">2</Property>
-				<Property Name="Source[0].itemID" Type="Str">{DB28CB26-AE20-41F8-84DC-022CC3DA62E7}</Property>
+				<Property Name="Source[0].itemID" Type="Str">{07E7BE00-FC89-43AA-8068-044EBE0500F4}</Property>
 				<Property Name="Source[0].type" Type="Str">Container</Property>
 				<Property Name="Source[1].destinationIndex" Type="Int">0</Property>
 				<Property Name="Source[1].itemID" Type="Ref">/Linux x64/Ballard ARINC 429 Engine.lvlib/RT Driver VI.vi</Property>
 				<Property Name="Source[1].properties[0].type" Type="Str">Remove front panel</Property>
 				<Property Name="Source[1].properties[0].value" Type="Bool">false</Property>
 				<Property Name="Source[1].properties[1].type" Type="Str">Remove block diagram</Property>
-				<Property Name="Source[1].properties[1].value" Type="Bool">false</Property>
+				<Property Name="Source[1].properties[1].value" Type="Bool">true</Property>
 				<Property Name="Source[1].properties[2].type" Type="Str">Allow debugging</Property>
 				<Property Name="Source[1].properties[2].value" Type="Bool">false</Property>
 				<Property Name="Source[1].propertiesCount" Type="Int">3</Property>
 				<Property Name="Source[1].sourceInclusion" Type="Str">Include</Property>
 				<Property Name="Source[1].type" Type="Str">VI</Property>
 				<Property Name="Source[2].Container.applyProperties" Type="Bool">true</Property>
-				<Property Name="Source[2].Container.applySaveSettings" Type="Bool">true</Property>
 				<Property Name="Source[2].itemID" Type="Ref">/Linux x64/NI VeriStand APIs</Property>
-				<Property Name="Source[2].properties[0].type" Type="Str">Remove front panel</Property>
-				<Property Name="Source[2].properties[0].value" Type="Bool">true</Property>
-				<Property Name="Source[2].properties[1].type" Type="Str">Remove block diagram</Property>
-				<Property Name="Source[2].properties[1].value" Type="Bool">true</Property>
-				<Property Name="Source[2].properties[2].type" Type="Str">Run when opened</Property>
+				<Property Name="Source[2].properties[0].type" Type="Str">Run when opened</Property>
+				<Property Name="Source[2].properties[0].value" Type="Bool">false</Property>
+				<Property Name="Source[2].properties[1].type" Type="Str">Allow debugging</Property>
+				<Property Name="Source[2].properties[1].value" Type="Bool">false</Property>
+				<Property Name="Source[2].properties[2].type" Type="Str">Auto error handling</Property>
 				<Property Name="Source[2].properties[2].value" Type="Bool">false</Property>
-				<Property Name="Source[2].properties[3].type" Type="Str">Allow debugging</Property>
-				<Property Name="Source[2].properties[3].value" Type="Bool">false</Property>
-				<Property Name="Source[2].properties[4].type" Type="Str">Auto error handling</Property>
-				<Property Name="Source[2].properties[4].value" Type="Bool">false</Property>
-				<Property Name="Source[2].propertiesCount" Type="Int">5</Property>
+				<Property Name="Source[2].propertiesCount" Type="Int">3</Property>
 				<Property Name="Source[2].type" Type="Str">Container</Property>
 				<Property Name="Source[3].Container.applyProperties" Type="Bool">true</Property>
 				<Property Name="Source[3].Container.applySaveSettings" Type="Bool">true</Property>

--- a/Source/Custom Device/Ballard ARINC 429 Custom Device.lvproj
+++ b/Source/Custom Device/Ballard ARINC 429 Custom Device.lvproj
@@ -1,5 +1,5 @@
 ﻿<?xml version='1.0' encoding='UTF-8'?>
-<Project Type="Project" LVVersion="21008000">
+<Project Type="Project" LVVersion="20008000">
 	<Property Name="CCSymbols" Type="Str"></Property>
 	<Property Name="NI.LV.All.SourceOnly" Type="Bool">true</Property>
 	<Property Name="NI.Project.Description" Type="Str"></Property>
@@ -409,25 +409,23 @@
 				<Item Name="whitespace.ctl" Type="VI" URL="/&lt;vilib&gt;/Utility/error.llb/whitespace.ctl"/>
 			</Item>
 			<Item Name="ActionVIOnLoad.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 System Explorer.lvlibp/Custom Device Support/System Explorer/Implementation/System Explorer/Dynamically Called/ActionVIOnLoad.vi"/>
-			<Item Name="Add Timing Channels RTM.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 System Explorer.lvlibp/System Explorer/Implementation/System Explorer/RTM/Add Timing Channels RTM.vi"/>
-			<Item Name="Asynchronous Execution Unit Compiled Information.ctl" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Engine/Custom Device/Asynchronous Execution Unit Compiled Information.ctl"/>
-			<Item Name="Block Data Reference.ctl" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/NI VeriStand/Custom Device API/Block Data Reference.ctl"/>
-			<Item Name="Can Add Timing Channels.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 System Explorer.lvlibp/System Explorer/Implementation/System Explorer/RTM/Can Add Timing Channels.vi"/>
-			<Item Name="Check if Custom Device is Enabled.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 System Explorer.lvlibp/System Explorer/Implementation/System Explorer/Check if Custom Device is Enabled.vi"/>
-			<Item Name="Compiled.Settings.ctl" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Engine/Custom Device/Compiled.Settings.ctl"/>
-			<Item Name="Custom Device Item Ref.ctl" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/NI VeriStand/Custom Device API/Custom Device Item Ref.ctl"/>
-			<Item Name="Custom Device Item Ref.ctl" Type="VI" URL="../../../Includes/Ballard ARINC 429 System Explorer.lvlibp/1abvi3w/vi.lib/NI VeriStand/Custom Device API/Custom Device Item Ref.ctl"/>
-			<Item Name="Custom Device RTM Dependency.ctl" Type="VI" URL="../../../Includes/Ballard ARINC 429 System Explorer.lvlibp/1abvi3w/vi.lib/NI VeriStand/Custom Device API/Custom Device RTM Dependency.ctl"/>
-			<Item Name="Data Reference.ctl" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/NI VeriStand/Custom Device API/Data Reference.ctl"/>
-			<Item Name="EnableDisable RTM.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 System Explorer.lvlibp/System Explorer/Implementation/System Explorer/RTM/EnableDisable RTM.vi"/>
-			<Item Name="Execution Unit Factory.lvclass" Type="LVClass" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Engine/Implementation/Execution Unit Factory/Execution Unit Factory.lvclass"/>
-			<Item Name="Execution Unit Factory.lvclass" Type="LVClass" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Engine/Interfaces/Execution Unit Factory/Execution Unit Factory.lvclass"/>
-			<Item Name="Execution Unit Information.ctl" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Engine/Interfaces/Controls/Execution Unit Information.ctl"/>
-			<Item Name="Execution Unit.lvclass" Type="LVClass" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Engine/Interfaces/Execution Unit/Execution Unit.lvclass"/>
-			<Item Name="Export Configuration RTM.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 System Explorer.lvlibp/System Explorer/Implementation/System Explorer/RTM/Export Configuration RTM.vi"/>
-			<Item Name="Import Configuration RTM.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 System Explorer.lvlibp/System Explorer/Implementation/System Explorer/RTM/Import Configuration RTM.vi"/>
+			<Item Name="BTI429LV.dll" Type="Document" URL="BTI429LV.dll">
+				<Property Name="NI.PreserveRelativePath" Type="Bool">true</Property>
+			</Item>
+			<Item Name="BTICardLV.dll" Type="Document" URL="BTICardLV.dll">
+				<Property Name="NI.PreserveRelativePath" Type="Bool">true</Property>
+			</Item>
+			<Item Name="DOMUserDefRef.dll" Type="Document" URL="DOMUserDefRef.dll">
+				<Property Name="NI.PreserveRelativePath" Type="Bool">true</Property>
+			</Item>
+			<Item Name="Error Converter (ErrCode or Status).vi" Type="VI" URL="/dev/git/custom-devices/niveristand-ballard-arinc429-custom-device/Source/Custom Device Support/Hardware API/Error Converter (ErrCode or Status).vi"/>
 			<Item Name="Initialize.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 System Explorer.lvlibp/System Explorer/Implementation/System Explorer/Initialize.vi"/>
-			<Item Name="Inline Execution Unit Compiled Information.ctl" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Engine/Custom Device/Inline Execution Unit Compiled Information.ctl"/>
+			<Item Name="mscorlib" Type="VI" URL="mscorlib">
+				<Property Name="NI.PreserveRelativePath" Type="Bool">true</Property>
+			</Item>
+			<Item Name="NationalInstruments.VeriStand.Internal" Type="Document" URL="NationalInstruments.VeriStand.Internal">
+				<Property Name="NI.PreserveRelativePath" Type="Bool">true</Property>
+			</Item>
 			<Item Name="NationalInstruments.VeriStand.SystemDefinitionAPI" Type="Document" URL="NationalInstruments.VeriStand.SystemDefinitionAPI">
 				<Property Name="NI.PreserveRelativePath" Type="Bool">true</Property>
 			</Item>
@@ -437,12 +435,11 @@
 			<Item Name="NationalInstruments.VeriStand.XMLReader" Type="Document" URL="NationalInstruments.VeriStand.XMLReader">
 				<Property Name="NI.PreserveRelativePath" Type="Bool">true</Property>
 			</Item>
-			<Item Name="RT Driver VI.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Engine/Custom Device/RT Driver VI.vi"/>
-			<Item Name="Shared Resources Factory.lvclass" Type="LVClass" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Engine/Implementation/Shared Resources Factory/Shared Resources Factory.lvclass"/>
-			<Item Name="Shared Resources Factory.lvclass" Type="LVClass" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Engine/Interfaces/Shared Resources Factory/Shared Resources Factory.lvclass"/>
+			<Item Name="NIVeriStand_DataServices.dll" Type="Document" URL="../../../Includes/NIVeriStand_DataServices.dll"/>
 			<Item Name="Shared Resources.lvclass" Type="LVClass" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Custom Device Support/Engine/Interfaces/Shared Resources/Shared Resources.lvclass"/>
-			<Item Name="System Explorer Dispatcher.lvclass" Type="LVClass" URL="../../../Includes/Ballard ARINC 429 System Explorer.lvlibp/System Explorer/Implementation/System Explorer Dispatcher/System Explorer Dispatcher.lvclass"/>
-			<Item Name="System Explorer Dispatcher.lvclass" Type="LVClass" URL="../../../Includes/Ballard ARINC 429 System Explorer.lvlibp/System Explorer/Interfaces/System Explorer Dispatcher/System Explorer Dispatcher.lvclass"/>
+			<Item Name="systemLogging.dll" Type="Document" URL="systemLogging.dll">
+				<Property Name="NI.PreserveRelativePath" Type="Bool">true</Property>
+			</Item>
 		</Item>
 		<Item Name="Build Specifications" Type="Build">
 			<Item Name="Configuration Debug" Type="Source Distribution">
@@ -768,10 +765,99 @@
 				<Item Name="Trim Whitespace.vi" Type="VI" URL="/&lt;vilib&gt;/Utility/error.llb/Trim Whitespace.vi"/>
 				<Item Name="whitespace.ctl" Type="VI" URL="/&lt;vilib&gt;/Utility/error.llb/whitespace.ctl"/>
 			</Item>
+			<Item Name="Ballard ARINC 429 Engine.lvlibp" Type="LVLibp" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp">
+				<Item Name="ARINC 429 Scripting.lvlib" Type="Library" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Scripting/ARINC 429/ARINC 429 Scripting.lvlib"/>
+				<Item Name="Asynchronous Process Parameters.ctl" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Engine/Custom Device/Asynchronous Process Parameters.ctl"/>
+				<Item Name="Ballard ARINC 429 Hardware API.lvlib" Type="Library" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Hardware API/Ballard ARINC 429 Hardware API.lvlib"/>
+				<Item Name="Ballard ARINC 429 Scripting.lvlib" Type="Library" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Scripting/Ballard/Ballard ARINC 429 Scripting.lvlib"/>
+				<Item Name="Ballard ARINC 429 System Explorer.lvlib" Type="Library" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/System Explorer/Implementation/System Explorer/Ballard ARINC 429 System Explorer.lvlib"/>
+				<Item Name="BTI429LV.lvlib" Type="Library" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/instr.lib/BTI429Lib/BTI429LV.lvlib"/>
+				<Item Name="BTICardLV.lvlib" Type="Library" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/instr.lib/BTICardLib/BTICardLV.lvlib"/>
+				<Item Name="Build Linux Log File Path.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Shared/Build Linux Log File Path.vi"/>
+				<Item Name="BuildHelpPath.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/error.llb/BuildHelpPath.vi"/>
+				<Item Name="Check Special Tags.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/error.llb/Check Special Tags.vi"/>
+				<Item Name="Clear Errors.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/error.llb/Clear Errors.vi"/>
+				<Item Name="Convert property node font to graphics font.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/error.llb/Convert property node font to graphics font.vi"/>
+				<Item Name="Create Directory Recursive.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/libraryn.llb/Create Directory Recursive.vi"/>
+				<Item Name="Create NI GUID.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/string/Create NI GUID.vi"/>
+				<Item Name="Custom Device API.lvlib" Type="Library" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/NI VeriStand/Custom Device API/Custom Device API.lvlib"/>
+				<Item Name="Custom Device Utility Library.lvlib" Type="Library" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/NI VeriStand/Custom Device Tools/Custom Device Utility Library/Custom Device Utility Library.lvlib"/>
+				<Item Name="Custom Device.lvlib" Type="Library" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Engine/Custom Device/Custom Device.lvlib"/>
+				<Item Name="Data Access Engine.lvlib" Type="Library" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/NI/NIVS Inline Async API/_Data Access Engine/Data Access Engine.lvlib"/>
+				<Item Name="Data Word Format.ctl" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Shared/Data Word Format.ctl"/>
+				<Item Name="Details Display Dialog.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/error.llb/Details Display Dialog.vi"/>
+				<Item Name="Device Parameters.ctl" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Shared/Device Parameters.ctl"/>
+				<Item Name="DialogType.ctl" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/error.llb/DialogType.ctl"/>
+				<Item Name="DialogTypeEnum.ctl" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/error.llb/DialogTypeEnum.ctl"/>
+				<Item Name="Direction Capability.ctl" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Shared/Direction Capability.ctl"/>
+				<Item Name="Encode Parameter and Update Word (32-bit).vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Shared/Encode Parameter and Update Word (32-bit).vi"/>
+				<Item Name="Encoding and Decoding.lvlib" Type="Library" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/NI/NI VeriStand Encoding and Decoding/Encoding and Decoding.lvlib"/>
+				<Item Name="Error Cluster From Error Code.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/error.llb/Error Cluster From Error Code.vi"/>
+				<Item Name="Error Code Database.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/error.llb/Error Code Database.vi"/>
+				<Item Name="ErrWarn.ctl" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/error.llb/ErrWarn.ctl"/>
+				<Item Name="eventvkey.ctl" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/event_ctls.llb/eventvkey.ctl"/>
+				<Item Name="Find Tag.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/error.llb/Find Tag.vi"/>
+				<Item Name="Format Message String.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/error.llb/Format Message String.vi"/>
+				<Item Name="General Error Handler Core CORE.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/error.llb/General Error Handler Core CORE.vi"/>
+				<Item Name="General Error Handler.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/error.llb/General Error Handler.vi"/>
+				<Item Name="Get Label Settings for RT.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Shared/Get Label Settings for RT.vi"/>
+				<Item Name="Get Rx Hardware Channel Data.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Shared/Get Rx Hardware Channel Data.vi"/>
+				<Item Name="Get Static Channel Reference for Frame.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Shared/Get Static Channel Reference for Frame.vi"/>
+				<Item Name="Get Status Error Channel Data References.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Shared/Get Status Error Channel Data References.vi"/>
+				<Item Name="Get String Text Bounds.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/error.llb/Get String Text Bounds.vi"/>
+				<Item Name="Get Text Rect.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/picture/picture.llb/Get Text Rect.vi"/>
+				<Item Name="Get Tx Hardware Channel Data.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Shared/Get Tx Hardware Channel Data.vi"/>
+				<Item Name="GetHelpDir.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/error.llb/GetHelpDir.vi"/>
+				<Item Name="GetRTHostConnectedProp.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/error.llb/GetRTHostConnectedProp.vi"/>
+				<Item Name="Implementation.lvlib" Type="Library" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Engine/Implementation/Implementation.lvlib"/>
+				<Item Name="Initialization Method.ctl" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Shared/Initialization Method.ctl"/>
+				<Item Name="Interfaces.lvlib" Type="Library" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Engine/Interfaces/Interfaces.lvlib"/>
+				<Item Name="Label Properties.ctl" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Shared/Label Properties.ctl"/>
+				<Item Name="Label.ctl" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Shared/Label.ctl"/>
+				<Item Name="Longest Line Length in Pixels.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/error.llb/Longest Line Length in Pixels.vi"/>
+				<Item Name="LV Config Read String.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/resource/dialog/lvconfig.llb/LV Config Read String.vi"/>
+				<Item Name="LVBoundsTypeDef.ctl" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/miscctls.llb/LVBoundsTypeDef.ctl"/>
+				<Item Name="LVRectTypeDef.ctl" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/miscctls.llb/LVRectTypeDef.ctl"/>
+				<Item Name="Map of Identifiers to Indexes.ctl" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Shared/Map of Identifiers to Indexes.ctl"/>
+				<Item Name="Map of Values Indexes to Channel and Label Indexes.ctl" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Shared/Map of Values Indexes to Channel and Label Indexes.ctl"/>
+				<Item Name="Messaging.lvlib" Type="Library" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/NI/VeriStand Custom Device Messaging/Messaging.lvlib"/>
+				<Item Name="NI_SystemLogging.lvlib" Type="Library" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/SystemLogging/NI_SystemLogging.lvlib"/>
+				<Item Name="nirviCommon.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/express/rvi/timingcommon/nirviCommon.vi"/>
+				<Item Name="Not Found Dialog.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/error.llb/Not Found Dialog.vi"/>
+				<Item Name="Pack Message Identifier.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Shared/Pack Message Identifier.vi"/>
+				<Item Name="Parameter Definition.ctl" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Shared/Parameter Definition.ctl"/>
+				<Item Name="RT Hardware Channel Settings.ctl" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Shared/RT Hardware Channel Settings.ctl"/>
+				<Item Name="RT Label Settings.ctl" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Shared/RT Label Settings.ctl"/>
+				<Item Name="RT Parameters.ctl" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Shared/RT Parameters.ctl"/>
+				<Item Name="Rx Channel Data Offsets.ctl" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Shared/Rx Channel Data Offsets.ctl"/>
+				<Item Name="Search and Replace Pattern.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/error.llb/Search and Replace Pattern.vi"/>
+				<Item Name="Set Bold Text.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/error.llb/Set Bold Text.vi"/>
+				<Item Name="Set String Value.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/error.llb/Set String Value.vi"/>
+				<Item Name="Simple Error Handler.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/error.llb/Simple Error Handler.vi"/>
+				<Item Name="subTimeDelay.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/express/express execution control/TimeDelayBlock.llb/subTimeDelay.vi"/>
+				<Item Name="TagReturnType.ctl" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/error.llb/TagReturnType.ctl"/>
+				<Item Name="Three Button Dialog CORE.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/error.llb/Three Button Dialog CORE.vi"/>
+				<Item Name="Three Button Dialog.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/error.llb/Three Button Dialog.vi"/>
+				<Item Name="Transfer Type.ctl" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Shared/Transfer Type.ctl"/>
+				<Item Name="Trim Whitespace.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/error.llb/Trim Whitespace.vi"/>
+				<Item Name="Verify File Exists and Not Empty.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Shared/Verify File Exists and Not Empty.vi"/>
+				<Item Name="VS Inline Async API.lvlib" Type="Library" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/NI/NIVS Inline Async API/_VS Inline Async API/VS Inline Async API.lvlib"/>
+				<Item Name="whitespace.ctl" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/error.llb/whitespace.ctl"/>
+			</Item>
+			<Item Name="BTI429LV.dll" Type="Document" URL="BTI429LV.dll">
+				<Property Name="NI.PreserveRelativePath" Type="Bool">true</Property>
+			</Item>
+			<Item Name="BTICardLV.dll" Type="Document" URL="BTICardLV.dll">
+				<Property Name="NI.PreserveRelativePath" Type="Bool">true</Property>
+			</Item>
+			<Item Name="Error Converter (ErrCode or Status).vi" Type="VI" URL="/dev/git/custom-devices/niveristand-ballard-arinc429-custom-device/Source/Custom Device Support/Hardware API/Error Converter (ErrCode or Status).vi"/>
 			<Item Name="NationalInstruments.VeriStand.SystemStorage" Type="Document" URL="NationalInstruments.VeriStand.SystemStorage">
 				<Property Name="NI.PreserveRelativePath" Type="Bool">true</Property>
 			</Item>
-			<Item Name="RT Driver VI.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Engine/Custom Device/RT Driver VI.vi"/>
+			<Item Name="NIVeriStand_DataServices.dll" Type="Document" URL="../../../Includes/NIVeriStand_DataServices.dll"/>
+			<Item Name="systemLogging.dll" Type="Document" URL="systemLogging.dll">
+				<Property Name="NI.PreserveRelativePath" Type="Bool">true</Property>
+			</Item>
 		</Item>
 		<Item Name="Build Specifications" Type="Build">
 			<Item Name="Engine Debug" Type="Source Distribution">
@@ -810,7 +896,6 @@
 				<Property Name="Bld_localDestDirType" Type="Str">relativeToCommon</Property>
 				<Property Name="Bld_postActionVIID" Type="Ref">/My Computer/Utility/Copy .LLB to NI VeriStand dir.vi</Property>
 				<Property Name="Bld_previewCacheID" Type="Str">{E24CF77A-EDD5-435E-91DE-CAC6522BEA2A}</Property>
-				<Property Name="Bld_removeVIObj" Type="Int">1</Property>
 				<Property Name="Bld_targetDestDir" Type="Path">Linux_x64/Ballard ARINC 429 Engine Linux64.llb</Property>
 				<Property Name="Bld_version.major" Type="Int">1</Property>
 				<Property Name="Destination[0].destName" Type="Str">Destination Directory</Property>
@@ -821,7 +906,7 @@
 				<Property Name="Destination[1].path" Type="Path">/Linux_x64</Property>
 				<Property Name="Destination[1].path.type" Type="Str">&lt;none&gt;</Property>
 				<Property Name="DestinationCount" Type="Int">2</Property>
-				<Property Name="Source[0].itemID" Type="Str">{07E7BE00-FC89-43AA-8068-044EBE0500F4}</Property>
+				<Property Name="Source[0].itemID" Type="Str">{DB28CB26-AE20-41F8-84DC-022CC3DA62E7}</Property>
 				<Property Name="Source[0].type" Type="Str">Container</Property>
 				<Property Name="Source[1].destinationIndex" Type="Int">0</Property>
 				<Property Name="Source[1].itemID" Type="Ref">/Linux x64/Ballard ARINC 429 Engine.lvlib/RT Driver VI.vi</Property>
@@ -835,14 +920,19 @@
 				<Property Name="Source[1].sourceInclusion" Type="Str">Include</Property>
 				<Property Name="Source[1].type" Type="Str">VI</Property>
 				<Property Name="Source[2].Container.applyProperties" Type="Bool">true</Property>
+				<Property Name="Source[2].Container.applySaveSettings" Type="Bool">true</Property>
 				<Property Name="Source[2].itemID" Type="Ref">/Linux x64/NI VeriStand APIs</Property>
-				<Property Name="Source[2].properties[0].type" Type="Str">Run when opened</Property>
-				<Property Name="Source[2].properties[0].value" Type="Bool">false</Property>
-				<Property Name="Source[2].properties[1].type" Type="Str">Allow debugging</Property>
-				<Property Name="Source[2].properties[1].value" Type="Bool">false</Property>
-				<Property Name="Source[2].properties[2].type" Type="Str">Auto error handling</Property>
+				<Property Name="Source[2].properties[0].type" Type="Str">Remove front panel</Property>
+				<Property Name="Source[2].properties[0].value" Type="Bool">true</Property>
+				<Property Name="Source[2].properties[1].type" Type="Str">Remove block diagram</Property>
+				<Property Name="Source[2].properties[1].value" Type="Bool">true</Property>
+				<Property Name="Source[2].properties[2].type" Type="Str">Run when opened</Property>
 				<Property Name="Source[2].properties[2].value" Type="Bool">false</Property>
-				<Property Name="Source[2].propertiesCount" Type="Int">3</Property>
+				<Property Name="Source[2].properties[3].type" Type="Str">Allow debugging</Property>
+				<Property Name="Source[2].properties[3].value" Type="Bool">false</Property>
+				<Property Name="Source[2].properties[4].type" Type="Str">Auto error handling</Property>
+				<Property Name="Source[2].properties[4].value" Type="Bool">false</Property>
+				<Property Name="Source[2].propertiesCount" Type="Int">5</Property>
 				<Property Name="Source[2].type" Type="Str">Container</Property>
 				<Property Name="Source[3].Container.applyProperties" Type="Bool">true</Property>
 				<Property Name="Source[3].Container.applySaveSettings" Type="Bool">true</Property>

--- a/Source/Custom Device/Ballard ARINC 429 Custom Device.lvproj
+++ b/Source/Custom Device/Ballard ARINC 429 Custom Device.lvproj
@@ -1,5 +1,5 @@
 ﻿<?xml version='1.0' encoding='UTF-8'?>
-<Project Type="Project" LVVersion="20008000">
+<Project Type="Project" LVVersion="23008000">
 	<Property Name="CCSymbols" Type="Str"></Property>
 	<Property Name="NI.LV.All.SourceOnly" Type="Bool">true</Property>
 	<Property Name="NI.Project.Description" Type="Str"></Property>
@@ -397,6 +397,7 @@
 				<Item Name="Three Button Dialog.vi" Type="VI" URL="/&lt;vilib&gt;/Utility/error.llb/Three Button Dialog.vi"/>
 				<Item Name="Trim Whitespace (String Array)__ogtk__jki_vi_tester.vi" Type="VI" URL="/&lt;vilib&gt;/addons/_JKI Toolkits/VI Tester/_support/Support.llb/Trim Whitespace (String Array)__ogtk__jki_vi_tester.vi"/>
 				<Item Name="Trim Whitespace (String)__ogtk__jki_vi_tester.vi" Type="VI" URL="/&lt;vilib&gt;/addons/_JKI Toolkits/VI Tester/_support/Support.llb/Trim Whitespace (String)__ogtk__jki_vi_tester.vi"/>
+				<Item Name="Trim Whitespace One-Sided.vi" Type="VI" URL="/&lt;vilib&gt;/Utility/error.llb/Trim Whitespace One-Sided.vi"/>
 				<Item Name="Trim Whitespace.vi" Type="VI" URL="/&lt;vilib&gt;/Utility/error.llb/Trim Whitespace.vi"/>
 				<Item Name="Trim Whitespace__ogtk__jki_vi_tester.vi" Type="VI" URL="/&lt;vilib&gt;/addons/_JKI Toolkits/VI Tester/_support/Support.llb/Trim Whitespace__ogtk__jki_vi_tester.vi"/>
 				<Item Name="Type Descriptor Enumeration__ogtk__jki_vi_tester.ctl" Type="VI" URL="/&lt;vilib&gt;/addons/_JKI Toolkits/VI Tester/_support/Support.llb/Type Descriptor Enumeration__ogtk__jki_vi_tester.ctl"/>
@@ -409,37 +410,41 @@
 				<Item Name="whitespace.ctl" Type="VI" URL="/&lt;vilib&gt;/Utility/error.llb/whitespace.ctl"/>
 			</Item>
 			<Item Name="ActionVIOnLoad.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 System Explorer.lvlibp/Custom Device Support/System Explorer/Implementation/System Explorer/Dynamically Called/ActionVIOnLoad.vi"/>
-			<Item Name="BTI429LV.dll" Type="Document" URL="BTI429LV.dll">
-				<Property Name="NI.PreserveRelativePath" Type="Bool">true</Property>
-			</Item>
-			<Item Name="BTICardLV.dll" Type="Document" URL="BTICardLV.dll">
-				<Property Name="NI.PreserveRelativePath" Type="Bool">true</Property>
-			</Item>
-			<Item Name="DOMUserDefRef.dll" Type="Document" URL="DOMUserDefRef.dll">
-				<Property Name="NI.PreserveRelativePath" Type="Bool">true</Property>
-			</Item>
-			<Item Name="Error Converter (ErrCode or Status).vi" Type="VI" URL="/dev/git/custom-devices/niveristand-ballard-arinc429-custom-device/Source/Custom Device Support/Hardware API/Error Converter (ErrCode or Status).vi"/>
+			<Item Name="Add Timing Channels RTM.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 System Explorer.lvlibp/System Explorer/Implementation/System Explorer/RTM/Add Timing Channels RTM.vi"/>
+			<Item Name="Asynchronous Execution Unit Compiled Information.ctl" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Engine/Custom Device/Asynchronous Execution Unit Compiled Information.ctl"/>
+			<Item Name="Block Data Reference.ctl" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/NI VeriStand/Custom Device API/Block Data Reference.ctl"/>
+			<Item Name="Can Add Timing Channels.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 System Explorer.lvlibp/System Explorer/Implementation/System Explorer/RTM/Can Add Timing Channels.vi"/>
+			<Item Name="Check if Custom Device is Enabled.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 System Explorer.lvlibp/System Explorer/Implementation/System Explorer/Check if Custom Device is Enabled.vi"/>
+			<Item Name="Compiled.Settings.ctl" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Engine/Custom Device/Compiled.Settings.ctl"/>
+			<Item Name="Custom Device Item Ref.ctl" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/NI VeriStand/Custom Device API/Custom Device Item Ref.ctl"/>
+			<Item Name="Custom Device Item Ref.ctl" Type="VI" URL="../../../Includes/Ballard ARINC 429 System Explorer.lvlibp/1abvi3w/vi.lib/NI VeriStand/Custom Device API/Custom Device Item Ref.ctl"/>
+			<Item Name="Custom Device RTM Dependency.ctl" Type="VI" URL="../../../Includes/Ballard ARINC 429 System Explorer.lvlibp/1abvi3w/vi.lib/NI VeriStand/Custom Device API/Custom Device RTM Dependency.ctl"/>
+			<Item Name="Data Reference.ctl" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/NI VeriStand/Custom Device API/Data Reference.ctl"/>
+			<Item Name="EnableDisable RTM.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 System Explorer.lvlibp/System Explorer/Implementation/System Explorer/RTM/EnableDisable RTM.vi"/>
+			<Item Name="Execution Unit Factory.lvclass" Type="LVClass" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Engine/Implementation/Execution Unit Factory/Execution Unit Factory.lvclass"/>
+			<Item Name="Execution Unit Factory.lvclass" Type="LVClass" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Engine/Interfaces/Execution Unit Factory/Execution Unit Factory.lvclass"/>
+			<Item Name="Execution Unit Information.ctl" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Engine/Interfaces/Controls/Execution Unit Information.ctl"/>
+			<Item Name="Execution Unit.lvclass" Type="LVClass" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Engine/Interfaces/Execution Unit/Execution Unit.lvclass"/>
+			<Item Name="Export Configuration RTM.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 System Explorer.lvlibp/System Explorer/Implementation/System Explorer/RTM/Export Configuration RTM.vi"/>
+			<Item Name="Import Configuration RTM.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 System Explorer.lvlibp/System Explorer/Implementation/System Explorer/RTM/Import Configuration RTM.vi"/>
 			<Item Name="Initialize.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 System Explorer.lvlibp/System Explorer/Implementation/System Explorer/Initialize.vi"/>
-			<Item Name="mscorlib" Type="VI" URL="mscorlib">
-				<Property Name="NI.PreserveRelativePath" Type="Bool">true</Property>
-			</Item>
-			<Item Name="NationalInstruments.VeriStand.Internal" Type="Document" URL="NationalInstruments.VeriStand.Internal">
-				<Property Name="NI.PreserveRelativePath" Type="Bool">true</Property>
-			</Item>
+			<Item Name="Inline Execution Unit Compiled Information.ctl" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Engine/Custom Device/Inline Execution Unit Compiled Information.ctl"/>
 			<Item Name="NationalInstruments.VeriStand.SystemDefinitionAPI" Type="Document" URL="NationalInstruments.VeriStand.SystemDefinitionAPI">
 				<Property Name="NI.PreserveRelativePath" Type="Bool">true</Property>
 			</Item>
 			<Item Name="NationalInstruments.VeriStand.SystemStorage" Type="Document" URL="NationalInstruments.VeriStand.SystemStorage">
 				<Property Name="NI.PreserveRelativePath" Type="Bool">true</Property>
 			</Item>
+			<Item Name="NationalInstruments.VeriStand.SystemStorage.dll" Type="Document" URL="../../../../../../../Dev/ni-central/src/veristand/main/veristandd/vs_all/objects/export/dist/release/Inst/Program Files/National Instruments/VeriStand 2020/NationalInstruments.VeriStand.SystemStorage.dll"/>
 			<Item Name="NationalInstruments.VeriStand.XMLReader" Type="Document" URL="NationalInstruments.VeriStand.XMLReader">
 				<Property Name="NI.PreserveRelativePath" Type="Bool">true</Property>
 			</Item>
-			<Item Name="NIVeriStand_DataServices.dll" Type="Document" URL="../../../Includes/NIVeriStand_DataServices.dll"/>
+			<Item Name="RT Driver VI.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Engine/Custom Device/RT Driver VI.vi"/>
+			<Item Name="Shared Resources Factory.lvclass" Type="LVClass" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Engine/Implementation/Shared Resources Factory/Shared Resources Factory.lvclass"/>
+			<Item Name="Shared Resources Factory.lvclass" Type="LVClass" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Engine/Interfaces/Shared Resources Factory/Shared Resources Factory.lvclass"/>
 			<Item Name="Shared Resources.lvclass" Type="LVClass" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Custom Device Support/Engine/Interfaces/Shared Resources/Shared Resources.lvclass"/>
-			<Item Name="systemLogging.dll" Type="Document" URL="systemLogging.dll">
-				<Property Name="NI.PreserveRelativePath" Type="Bool">true</Property>
-			</Item>
+			<Item Name="System Explorer Dispatcher.lvclass" Type="LVClass" URL="../../../Includes/Ballard ARINC 429 System Explorer.lvlibp/System Explorer/Implementation/System Explorer Dispatcher/System Explorer Dispatcher.lvclass"/>
+			<Item Name="System Explorer Dispatcher.lvclass" Type="LVClass" URL="../../../Includes/Ballard ARINC 429 System Explorer.lvlibp/System Explorer/Interfaces/System Explorer Dispatcher/System Explorer Dispatcher.lvclass"/>
 		</Item>
 		<Item Name="Build Specifications" Type="Build">
 			<Item Name="Configuration Debug" Type="Source Distribution">
@@ -762,102 +767,15 @@
 				<Item Name="TagReturnType.ctl" Type="VI" URL="/&lt;vilib&gt;/Utility/error.llb/TagReturnType.ctl"/>
 				<Item Name="Three Button Dialog CORE.vi" Type="VI" URL="/&lt;vilib&gt;/Utility/error.llb/Three Button Dialog CORE.vi"/>
 				<Item Name="Three Button Dialog.vi" Type="VI" URL="/&lt;vilib&gt;/Utility/error.llb/Three Button Dialog.vi"/>
+				<Item Name="Trim Whitespace One-Sided.vi" Type="VI" URL="/&lt;vilib&gt;/Utility/error.llb/Trim Whitespace One-Sided.vi"/>
 				<Item Name="Trim Whitespace.vi" Type="VI" URL="/&lt;vilib&gt;/Utility/error.llb/Trim Whitespace.vi"/>
 				<Item Name="whitespace.ctl" Type="VI" URL="/&lt;vilib&gt;/Utility/error.llb/whitespace.ctl"/>
 			</Item>
-			<Item Name="Ballard ARINC 429 Engine.lvlibp" Type="LVLibp" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp">
-				<Item Name="ARINC 429 Scripting.lvlib" Type="Library" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Scripting/ARINC 429/ARINC 429 Scripting.lvlib"/>
-				<Item Name="Asynchronous Process Parameters.ctl" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Engine/Custom Device/Asynchronous Process Parameters.ctl"/>
-				<Item Name="Ballard ARINC 429 Hardware API.lvlib" Type="Library" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Hardware API/Ballard ARINC 429 Hardware API.lvlib"/>
-				<Item Name="Ballard ARINC 429 Scripting.lvlib" Type="Library" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Scripting/Ballard/Ballard ARINC 429 Scripting.lvlib"/>
-				<Item Name="Ballard ARINC 429 System Explorer.lvlib" Type="Library" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/System Explorer/Implementation/System Explorer/Ballard ARINC 429 System Explorer.lvlib"/>
-				<Item Name="BTI429LV.lvlib" Type="Library" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/instr.lib/BTI429Lib/BTI429LV.lvlib"/>
-				<Item Name="BTICardLV.lvlib" Type="Library" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/instr.lib/BTICardLib/BTICardLV.lvlib"/>
-				<Item Name="Build Linux Log File Path.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Shared/Build Linux Log File Path.vi"/>
-				<Item Name="BuildHelpPath.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/error.llb/BuildHelpPath.vi"/>
-				<Item Name="Check Special Tags.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/error.llb/Check Special Tags.vi"/>
-				<Item Name="Clear Errors.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/error.llb/Clear Errors.vi"/>
-				<Item Name="Convert property node font to graphics font.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/error.llb/Convert property node font to graphics font.vi"/>
-				<Item Name="Create Directory Recursive.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/libraryn.llb/Create Directory Recursive.vi"/>
-				<Item Name="Create NI GUID.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/string/Create NI GUID.vi"/>
-				<Item Name="Custom Device API.lvlib" Type="Library" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/NI VeriStand/Custom Device API/Custom Device API.lvlib"/>
-				<Item Name="Custom Device Utility Library.lvlib" Type="Library" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/NI VeriStand/Custom Device Tools/Custom Device Utility Library/Custom Device Utility Library.lvlib"/>
-				<Item Name="Custom Device.lvlib" Type="Library" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Engine/Custom Device/Custom Device.lvlib"/>
-				<Item Name="Data Access Engine.lvlib" Type="Library" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/NI/NIVS Inline Async API/_Data Access Engine/Data Access Engine.lvlib"/>
-				<Item Name="Data Word Format.ctl" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Shared/Data Word Format.ctl"/>
-				<Item Name="Details Display Dialog.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/error.llb/Details Display Dialog.vi"/>
-				<Item Name="Device Parameters.ctl" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Shared/Device Parameters.ctl"/>
-				<Item Name="DialogType.ctl" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/error.llb/DialogType.ctl"/>
-				<Item Name="DialogTypeEnum.ctl" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/error.llb/DialogTypeEnum.ctl"/>
-				<Item Name="Direction Capability.ctl" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Shared/Direction Capability.ctl"/>
-				<Item Name="Encode Parameter and Update Word (32-bit).vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Shared/Encode Parameter and Update Word (32-bit).vi"/>
-				<Item Name="Encoding and Decoding.lvlib" Type="Library" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/NI/NI VeriStand Encoding and Decoding/Encoding and Decoding.lvlib"/>
-				<Item Name="Error Cluster From Error Code.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/error.llb/Error Cluster From Error Code.vi"/>
-				<Item Name="Error Code Database.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/error.llb/Error Code Database.vi"/>
-				<Item Name="ErrWarn.ctl" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/error.llb/ErrWarn.ctl"/>
-				<Item Name="eventvkey.ctl" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/event_ctls.llb/eventvkey.ctl"/>
-				<Item Name="Find Tag.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/error.llb/Find Tag.vi"/>
-				<Item Name="Format Message String.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/error.llb/Format Message String.vi"/>
-				<Item Name="General Error Handler Core CORE.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/error.llb/General Error Handler Core CORE.vi"/>
-				<Item Name="General Error Handler.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/error.llb/General Error Handler.vi"/>
-				<Item Name="Get Label Settings for RT.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Shared/Get Label Settings for RT.vi"/>
-				<Item Name="Get Rx Hardware Channel Data.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Shared/Get Rx Hardware Channel Data.vi"/>
-				<Item Name="Get Static Channel Reference for Frame.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Shared/Get Static Channel Reference for Frame.vi"/>
-				<Item Name="Get Status Error Channel Data References.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Shared/Get Status Error Channel Data References.vi"/>
-				<Item Name="Get String Text Bounds.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/error.llb/Get String Text Bounds.vi"/>
-				<Item Name="Get Text Rect.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/picture/picture.llb/Get Text Rect.vi"/>
-				<Item Name="Get Tx Hardware Channel Data.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Shared/Get Tx Hardware Channel Data.vi"/>
-				<Item Name="GetHelpDir.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/error.llb/GetHelpDir.vi"/>
-				<Item Name="GetRTHostConnectedProp.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/error.llb/GetRTHostConnectedProp.vi"/>
-				<Item Name="Implementation.lvlib" Type="Library" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Engine/Implementation/Implementation.lvlib"/>
-				<Item Name="Initialization Method.ctl" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Shared/Initialization Method.ctl"/>
-				<Item Name="Interfaces.lvlib" Type="Library" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Engine/Interfaces/Interfaces.lvlib"/>
-				<Item Name="Label Properties.ctl" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Shared/Label Properties.ctl"/>
-				<Item Name="Label.ctl" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Shared/Label.ctl"/>
-				<Item Name="Longest Line Length in Pixels.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/error.llb/Longest Line Length in Pixels.vi"/>
-				<Item Name="LV Config Read String.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/resource/dialog/lvconfig.llb/LV Config Read String.vi"/>
-				<Item Name="LVBoundsTypeDef.ctl" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/miscctls.llb/LVBoundsTypeDef.ctl"/>
-				<Item Name="LVRectTypeDef.ctl" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/miscctls.llb/LVRectTypeDef.ctl"/>
-				<Item Name="Map of Identifiers to Indexes.ctl" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Shared/Map of Identifiers to Indexes.ctl"/>
-				<Item Name="Map of Values Indexes to Channel and Label Indexes.ctl" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Shared/Map of Values Indexes to Channel and Label Indexes.ctl"/>
-				<Item Name="Messaging.lvlib" Type="Library" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/NI/VeriStand Custom Device Messaging/Messaging.lvlib"/>
-				<Item Name="NI_SystemLogging.lvlib" Type="Library" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/SystemLogging/NI_SystemLogging.lvlib"/>
-				<Item Name="nirviCommon.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/express/rvi/timingcommon/nirviCommon.vi"/>
-				<Item Name="Not Found Dialog.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/error.llb/Not Found Dialog.vi"/>
-				<Item Name="Pack Message Identifier.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Shared/Pack Message Identifier.vi"/>
-				<Item Name="Parameter Definition.ctl" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Shared/Parameter Definition.ctl"/>
-				<Item Name="RT Hardware Channel Settings.ctl" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Shared/RT Hardware Channel Settings.ctl"/>
-				<Item Name="RT Label Settings.ctl" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Shared/RT Label Settings.ctl"/>
-				<Item Name="RT Parameters.ctl" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Shared/RT Parameters.ctl"/>
-				<Item Name="Rx Channel Data Offsets.ctl" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Shared/Rx Channel Data Offsets.ctl"/>
-				<Item Name="Search and Replace Pattern.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/error.llb/Search and Replace Pattern.vi"/>
-				<Item Name="Set Bold Text.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/error.llb/Set Bold Text.vi"/>
-				<Item Name="Set String Value.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/error.llb/Set String Value.vi"/>
-				<Item Name="Simple Error Handler.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/error.llb/Simple Error Handler.vi"/>
-				<Item Name="subTimeDelay.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/express/express execution control/TimeDelayBlock.llb/subTimeDelay.vi"/>
-				<Item Name="TagReturnType.ctl" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/error.llb/TagReturnType.ctl"/>
-				<Item Name="Three Button Dialog CORE.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/error.llb/Three Button Dialog CORE.vi"/>
-				<Item Name="Three Button Dialog.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/error.llb/Three Button Dialog.vi"/>
-				<Item Name="Transfer Type.ctl" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Shared/Transfer Type.ctl"/>
-				<Item Name="Trim Whitespace.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/error.llb/Trim Whitespace.vi"/>
-				<Item Name="Verify File Exists and Not Empty.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Shared/Verify File Exists and Not Empty.vi"/>
-				<Item Name="VS Inline Async API.lvlib" Type="Library" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/NI/NIVS Inline Async API/_VS Inline Async API/VS Inline Async API.lvlib"/>
-				<Item Name="whitespace.ctl" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/1abvi3w/vi.lib/Utility/error.llb/whitespace.ctl"/>
-			</Item>
-			<Item Name="BTI429LV.dll" Type="Document" URL="BTI429LV.dll">
-				<Property Name="NI.PreserveRelativePath" Type="Bool">true</Property>
-			</Item>
-			<Item Name="BTICardLV.dll" Type="Document" URL="BTICardLV.dll">
-				<Property Name="NI.PreserveRelativePath" Type="Bool">true</Property>
-			</Item>
-			<Item Name="Error Converter (ErrCode or Status).vi" Type="VI" URL="/dev/git/custom-devices/niveristand-ballard-arinc429-custom-device/Source/Custom Device Support/Hardware API/Error Converter (ErrCode or Status).vi"/>
 			<Item Name="NationalInstruments.VeriStand.SystemStorage" Type="Document" URL="NationalInstruments.VeriStand.SystemStorage">
 				<Property Name="NI.PreserveRelativePath" Type="Bool">true</Property>
 			</Item>
-			<Item Name="NIVeriStand_DataServices.dll" Type="Document" URL="../../../Includes/NIVeriStand_DataServices.dll"/>
-			<Item Name="systemLogging.dll" Type="Document" URL="systemLogging.dll">
-				<Property Name="NI.PreserveRelativePath" Type="Bool">true</Property>
-			</Item>
+			<Item Name="NationalInstruments.VeriStand.SystemStorage.dll" Type="Document" URL="../../../../../../../Dev/ni-central/src/veristand/main/veristandd/vs_all/objects/export/dist/release/Inst/Program Files/National Instruments/VeriStand 2020/NationalInstruments.VeriStand.SystemStorage.dll"/>
+			<Item Name="RT Driver VI.vi" Type="VI" URL="../../../Includes/Ballard ARINC 429 Engine.lvlibp/Engine/Custom Device/RT Driver VI.vi"/>
 		</Item>
 		<Item Name="Build Specifications" Type="Build">
 			<Item Name="Engine Debug" Type="Source Distribution">
@@ -906,14 +824,14 @@
 				<Property Name="Destination[1].path" Type="Path">/Linux_x64</Property>
 				<Property Name="Destination[1].path.type" Type="Str">&lt;none&gt;</Property>
 				<Property Name="DestinationCount" Type="Int">2</Property>
-				<Property Name="Source[0].itemID" Type="Str">{DB28CB26-AE20-41F8-84DC-022CC3DA62E7}</Property>
+				<Property Name="Source[0].itemID" Type="Str">{F5C9C4F4-ED2A-492B-9641-E1F1492A3593}</Property>
 				<Property Name="Source[0].type" Type="Str">Container</Property>
 				<Property Name="Source[1].destinationIndex" Type="Int">0</Property>
 				<Property Name="Source[1].itemID" Type="Ref">/Linux x64/Ballard ARINC 429 Engine.lvlib/RT Driver VI.vi</Property>
 				<Property Name="Source[1].properties[0].type" Type="Str">Remove front panel</Property>
 				<Property Name="Source[1].properties[0].value" Type="Bool">false</Property>
 				<Property Name="Source[1].properties[1].type" Type="Str">Remove block diagram</Property>
-				<Property Name="Source[1].properties[1].value" Type="Bool">true</Property>
+				<Property Name="Source[1].properties[1].value" Type="Bool">false</Property>
 				<Property Name="Source[1].properties[2].type" Type="Str">Allow debugging</Property>
 				<Property Name="Source[1].properties[2].value" Type="Bool">false</Property>
 				<Property Name="Source[1].propertiesCount" Type="Int">3</Property>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,11 +17,11 @@ stages:
   - template: azure-templates/stages.yml@niveristand-custom-device-build-tools
     parameters:
       lvVersionsToBuild:
+        - version: '2021'
+          bitness: '64bit'
         - version: '2023'
           bitness: '64bit'
         - version: '2024'
-          bitness: '64bit'
-        - version: '2025'
           bitness: '64bit'
 
       buildSteps:
@@ -65,7 +65,7 @@ stages:
           target: 'Linux x64'
           buildSpec: 'Engine Release'
 
-      releaseVersion: '25.0.0'
+      releaseVersion: '24.8.0'
       buildOutputLocation: 'Source\Built'
       archiveLocation: '\\nirvana\Measurements\VeriStandAddons\ballard_arinc_429'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,11 +17,11 @@ stages:
   - template: azure-templates/stages.yml@niveristand-custom-device-build-tools
     parameters:
       lvVersionsToBuild:
-        - version: '2021'
-          bitness: '64bit'
         - version: '2023'
           bitness: '64bit'
         - version: '2024'
+          bitness: '64bit'
+        - version: '2025'
           bitness: '64bit'
 
       buildSteps:
@@ -65,7 +65,7 @@ stages:
           target: 'Linux x64'
           buildSpec: 'Engine Release'
 
-      releaseVersion: '24.8.0'
+      releaseVersion: '25.0.0'
       buildOutputLocation: 'Source\Built'
       archiveLocation: '\\nirvana\Measurements\VeriStandAddons\ballard_arinc_429'
 


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-ballard-arinc429-custom-device/blob/master/CONTRIBUTING.md).

TODO: Check the above box with an 'x' indicating you've read and followed [CONTRIBUTING.md](https://github.com/ni/niveristand-ballard-arinc429-custom-device/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?
Revert prev. proj. changes [WA]. Just disable RT Driver.vi block diag removal. Rebuild with supported LVs


Disabled this option for RT driver in order to fix the work around.
![image](https://github.com/user-attachments/assets/91ea0846-05da-41e9-b6b2-05bd7ca67e0c)


### Why should this Pull Request be merged?

Required for future. release.

### What testing has been done?

NA
